### PR TITLE
Start #19 - support comparing against literals.

### DIFF
--- a/qb/cmp.go
+++ b/qb/cmp.go
@@ -26,11 +26,9 @@ const (
 
 // Cmp if a filtering comparator that is used in WHERE and IF clauses.
 type Cmp struct {
-	op      op
-	column  string
-	name    string
-	literal string
-	fn      *Func
+	op     op
+	column string
+	value  value
 }
 
 func (c Cmp) writeCql(cql *bytes.Buffer) (names []string) {
@@ -53,20 +51,7 @@ func (c Cmp) writeCql(cql *bytes.Buffer) (names []string) {
 	case cnt:
 		cql.WriteString(" CONTAINS ")
 	}
-
-	if c.fn != nil {
-		return c.fn.writeCql(cql)
-	}
-	if c.literal != "" {
-		cql.WriteString(c.literal)
-		return []string{}
-	}
-
-	cql.WriteByte('?')
-	if c.name != "" {
-		return []string{c.name}
-	}
-	return []string{c.column}
+	return c.value.writeCql(cql)
 }
 
 // Eq produces column=?.
@@ -74,6 +59,7 @@ func Eq(column string) Cmp {
 	return Cmp{
 		op:     eq,
 		column: column,
+		value:  param(column),
 	}
 }
 
@@ -82,16 +68,16 @@ func EqNamed(column, name string) Cmp {
 	return Cmp{
 		op:     eq,
 		column: column,
-		name:   name,
+		value:  param(name),
 	}
 }
 
 // EqLit produces column=literal, and does not add a parameter to the query.
 func EqLit(column, literal string) Cmp {
 	return Cmp{
-		op:      eq,
-		column:  column,
-		literal: literal,
+		op:     eq,
+		column: column,
+		value:  lit(literal),
 	}
 }
 
@@ -100,7 +86,7 @@ func EqFunc(column string, fn *Func) Cmp {
 	return Cmp{
 		op:     eq,
 		column: column,
-		fn:     fn,
+		value:  fn,
 	}
 }
 
@@ -109,6 +95,7 @@ func Lt(column string) Cmp {
 	return Cmp{
 		op:     lt,
 		column: column,
+		value:  param(column),
 	}
 }
 
@@ -117,16 +104,16 @@ func LtNamed(column, name string) Cmp {
 	return Cmp{
 		op:     lt,
 		column: column,
-		name:   name,
+		value:  param(name),
 	}
 }
 
 // LtLit produces column<literal and does not add a parameter to the query.
 func LtLit(column, literal string) Cmp {
 	return Cmp{
-		op:      lt,
-		column:  column,
-		literal: literal,
+		op:     lt,
+		column: column,
+		value:  lit(literal),
 	}
 }
 
@@ -135,7 +122,7 @@ func LtFunc(column string, fn *Func) Cmp {
 	return Cmp{
 		op:     lt,
 		column: column,
-		fn:     fn,
+		value:  fn,
 	}
 }
 
@@ -144,6 +131,7 @@ func LtOrEq(column string) Cmp {
 	return Cmp{
 		op:     leq,
 		column: column,
+		value:  param(column),
 	}
 }
 
@@ -152,16 +140,16 @@ func LtOrEqNamed(column, name string) Cmp {
 	return Cmp{
 		op:     leq,
 		column: column,
-		name:   name,
+		value:  param(name),
 	}
 }
 
 // LtOrEqLit produces column<=literal and does not add a parameter to the query.
 func LtOrEqLit(column, literal string) Cmp {
 	return Cmp{
-		op:      leq,
-		column:  column,
-		literal: literal,
+		op:     leq,
+		column: column,
+		value:  lit(literal),
 	}
 }
 
@@ -170,7 +158,7 @@ func LtOrEqFunc(column string, fn *Func) Cmp {
 	return Cmp{
 		op:     leq,
 		column: column,
-		fn:     fn,
+		value:  fn,
 	}
 }
 
@@ -179,6 +167,7 @@ func Gt(column string) Cmp {
 	return Cmp{
 		op:     gt,
 		column: column,
+		value:  param(column),
 	}
 }
 
@@ -187,16 +176,16 @@ func GtNamed(column, name string) Cmp {
 	return Cmp{
 		op:     gt,
 		column: column,
-		name:   name,
+		value:  param(name),
 	}
 }
 
 // GtLit produces column>literal and does not add a parameter to the query.
 func GtLit(column, literal string) Cmp {
 	return Cmp{
-		op:      gt,
-		column:  column,
-		literal: literal,
+		op:     gt,
+		column: column,
+		value:  lit(literal),
 	}
 }
 
@@ -205,7 +194,7 @@ func GtFunc(column string, fn *Func) Cmp {
 	return Cmp{
 		op:     gt,
 		column: column,
-		fn:     fn,
+		value:  fn,
 	}
 }
 
@@ -214,6 +203,7 @@ func GtOrEq(column string) Cmp {
 	return Cmp{
 		op:     geq,
 		column: column,
+		value:  param(column),
 	}
 }
 
@@ -222,16 +212,16 @@ func GtOrEqNamed(column, name string) Cmp {
 	return Cmp{
 		op:     geq,
 		column: column,
-		name:   name,
+		value:  param(name),
 	}
 }
 
 // GtOrEqLit produces column>=literal and does not add a parameter to the query.
 func GtOrEqLit(column, literal string) Cmp {
 	return Cmp{
-		op:      geq,
-		column:  column,
-		literal: literal,
+		op:     geq,
+		column: column,
+		value:  lit(literal),
 	}
 }
 
@@ -240,7 +230,7 @@ func GtOrEqFunc(column string, fn *Func) Cmp {
 	return Cmp{
 		op:     geq,
 		column: column,
-		fn:     fn,
+		value:  fn,
 	}
 }
 
@@ -249,6 +239,7 @@ func In(column string) Cmp {
 	return Cmp{
 		op:     in,
 		column: column,
+		value:  param(column),
 	}
 }
 
@@ -257,16 +248,16 @@ func InNamed(column, name string) Cmp {
 	return Cmp{
 		op:     in,
 		column: column,
-		name:   name,
+		value:  param(name),
 	}
 }
 
 // InLit produces column IN literal and does not add a parameter to the query.
 func InLit(column, literal string) Cmp {
 	return Cmp{
-		op:      in,
-		column:  column,
-		literal: literal,
+		op:     in,
+		column: column,
+		value:  lit(literal),
 	}
 }
 
@@ -275,6 +266,7 @@ func Contains(column string) Cmp {
 	return Cmp{
 		op:     cnt,
 		column: column,
+		value:  param(column),
 	}
 }
 
@@ -283,16 +275,16 @@ func ContainsNamed(column, name string) Cmp {
 	return Cmp{
 		op:     cnt,
 		column: column,
-		name:   name,
+		value:  param(name),
 	}
 }
 
 // ContainsLit produces column CONTAINS literal and does not add a parameter to the query.
 func ContainsLit(column, literal string) Cmp {
 	return Cmp{
-		op:      cnt,
-		column:  column,
-		literal: literal,
+		op:     cnt,
+		column: column,
+		value:  lit(literal),
 	}
 }
 

--- a/qb/cmp.go
+++ b/qb/cmp.go
@@ -26,10 +26,11 @@ const (
 
 // Cmp if a filtering comparator that is used in WHERE and IF clauses.
 type Cmp struct {
-	op     op
-	column string
-	name   string
-	fn     *Func
+	op      op
+	column  string
+	name    string
+	literal string
+	fn      *Func
 }
 
 func (c Cmp) writeCql(cql *bytes.Buffer) (names []string) {
@@ -54,17 +55,18 @@ func (c Cmp) writeCql(cql *bytes.Buffer) (names []string) {
 	}
 
 	if c.fn != nil {
-		names = append(names, c.fn.writeCql(cql)...)
-	} else {
-		cql.WriteByte('?')
-		if c.name == "" {
-			names = append(names, c.column)
-		} else {
-			names = append(names, c.name)
-		}
+		return c.fn.writeCql(cql)
+	}
+	if c.literal != "" {
+		cql.WriteString(c.literal)
+		return []string{}
 	}
 
-	return
+	cql.WriteByte('?')
+	if c.name != "" {
+		return []string{c.name}
+	}
+	return []string{c.column}
 }
 
 // Eq produces column=?.
@@ -81,6 +83,15 @@ func EqNamed(column, name string) Cmp {
 		op:     eq,
 		column: column,
 		name:   name,
+	}
+}
+
+// EqLit produces column=literal, and does not add a parameter to the query.
+func EqLit(column, literal string) Cmp {
+	return Cmp{
+		op:      eq,
+		column:  column,
+		literal: literal,
 	}
 }
 
@@ -110,6 +121,15 @@ func LtNamed(column, name string) Cmp {
 	}
 }
 
+// LtLit produces column<literal and does not add a parameter to the query.
+func LtLit(column, literal string) Cmp {
+	return Cmp{
+		op:      lt,
+		column:  column,
+		literal: literal,
+	}
+}
+
 // LtFunc produces column<someFunc(?...).
 func LtFunc(column string, fn *Func) Cmp {
 	return Cmp{
@@ -133,6 +153,15 @@ func LtOrEqNamed(column, name string) Cmp {
 		op:     leq,
 		column: column,
 		name:   name,
+	}
+}
+
+// LtOrEqLit produces column<=literal and does not add a parameter to the query.
+func LtOrEqLit(column, literal string) Cmp {
+	return Cmp{
+		op:      leq,
+		column:  column,
+		literal: literal,
 	}
 }
 
@@ -162,6 +191,15 @@ func GtNamed(column, name string) Cmp {
 	}
 }
 
+// GtLit produces column>literal and does not add a parameter to the query.
+func GtLit(column, literal string) Cmp {
+	return Cmp{
+		op:      gt,
+		column:  column,
+		literal: literal,
+	}
+}
+
 // GtFunc produces column>someFunc(?...).
 func GtFunc(column string, fn *Func) Cmp {
 	return Cmp{
@@ -185,6 +223,15 @@ func GtOrEqNamed(column, name string) Cmp {
 		op:     geq,
 		column: column,
 		name:   name,
+	}
+}
+
+// GtOrEqLit produces column>=literal and does not add a parameter to the query.
+func GtOrEqLit(column, literal string) Cmp {
+	return Cmp{
+		op:      geq,
+		column:  column,
+		literal: literal,
 	}
 }
 
@@ -214,6 +261,15 @@ func InNamed(column, name string) Cmp {
 	}
 }
 
+// InLit produces column IN literal and does not add a parameter to the query.
+func InLit(column, literal string) Cmp {
+	return Cmp{
+		op:      in,
+		column:  column,
+		literal: literal,
+	}
+}
+
 // Contains produces column CONTAINS ?.
 func Contains(column string) Cmp {
 	return Cmp{
@@ -228,6 +284,15 @@ func ContainsNamed(column, name string) Cmp {
 		op:     cnt,
 		column: column,
 		name:   name,
+	}
+}
+
+// ContainsLit produces column CONTAINS literal and does not add a parameter to the query.
+func ContainsLit(column, literal string) Cmp {
+	return Cmp{
+		op:      cnt,
+		column:  column,
+		literal: literal,
 	}
 }
 

--- a/qb/cmp_test.go
+++ b/qb/cmp_test.go
@@ -91,6 +91,43 @@ func TestCmp(t *testing.T) {
 			N: []string{"name"},
 		},
 
+		// Comparisons against literals.
+		{
+			C: EqLit("eq", "literal_value"),
+			S: "eq=literal_value",
+			N: []string{},
+		},
+		{
+			C: LtLit("lt", "literal_value"),
+			S: "lt<literal_value",
+			N: []string{},
+		},
+		{
+			C: LtOrEqLit("lt", "literal_value"),
+			S: "lt<=literal_value",
+			N: []string{},
+		},
+		{
+			C: GtLit("gt", "literal_value"),
+			S: "gt>literal_value",
+			N: []string{},
+		},
+		{
+			C: GtOrEqLit("gt", "literal_value"),
+			S: "gt>=literal_value",
+			N: []string{},
+		},
+		{
+			C: InLit("in", "literal_value"),
+			S: "in IN literal_value",
+			N: []string{},
+		},
+		{
+			C: ContainsLit("cnt", "literal_value"),
+			S: "cnt CONTAINS literal_value",
+			N: []string{},
+		},
+
 		// Functions
 		{
 			C: EqFunc("eq", Fn("fn", "arg0", "arg1")),

--- a/qb/func.go
+++ b/qb/func.go
@@ -18,6 +18,15 @@ type Func struct {
 	ParamNames []string
 }
 
+func (f *Func) clone() value {
+	paramNames := make([]string, len(f.ParamNames))
+	copy(f.ParamNames, paramNames)
+	return &Func{
+		Name:       f.Name,
+		ParamNames: paramNames,
+	}
+}
+
 func (f *Func) writeCql(cql *bytes.Buffer) (names []string) {
 	cql.WriteString(f.Name)
 	cql.WriteByte('(')

--- a/qb/insert.go
+++ b/qb/insert.go
@@ -11,10 +11,16 @@ import (
 	"bytes"
 )
 
+// initializer specifies an value for a column in an insert operation.
+type initializer struct {
+	column string
+	value  value
+}
+
 // InsertBuilder builds CQL INSERT statements.
 type InsertBuilder struct {
 	table   string
-	columns columns
+	columns []initializer
 	unique  bool
 	using   using
 }
@@ -37,12 +43,22 @@ func (b *InsertBuilder) ToCql() (stmt string, names []string) {
 	cql.WriteByte(' ')
 
 	cql.WriteByte('(')
-	b.columns.writeCql(&cql)
-	names = append(names, b.columns...)
+	nCols := len(b.columns)
+	for i, init := range b.columns {
+		cql.WriteString(init.column)
+		if i < nCols-1 {
+			cql.WriteByte(',')
+		}
+	}
 	cql.WriteString(") ")
 
 	cql.WriteString("VALUES (")
-	placeholders(&cql, len(b.columns))
+	for i, init := range b.columns {
+		names = append(names, init.value.writeCql(&cql)...)
+		if i < nCols-1 {
+			cql.WriteByte(',')
+		}
+	}
 	cql.WriteString(") ")
 
 	names = append(names, b.using.writeCql(&cql)...)
@@ -63,7 +79,39 @@ func (b *InsertBuilder) Into(table string) *InsertBuilder {
 
 // Columns adds insert columns to the query.
 func (b *InsertBuilder) Columns(columns ...string) *InsertBuilder {
-	b.columns = append(b.columns, columns...)
+	for _, c := range columns {
+		b.columns = append(b.columns, initializer{
+			column: c,
+			value:  param(c),
+		})
+	}
+	return b
+}
+
+// NamedColumn adds an insert column with a custom parameter name.
+func (b *InsertBuilder) NamedColumn(column, name string) *InsertBuilder {
+	b.columns = append(b.columns, initializer{
+		column: column,
+		value:  param(name),
+	})
+	return b
+}
+
+// LitColumn adds an insert column with a literal value to the query.
+func (b *InsertBuilder) LitColumn(column, literal string) *InsertBuilder {
+	b.columns = append(b.columns, initializer{
+		column: column,
+		value:  lit(literal),
+	})
+	return b
+}
+
+// FuncColumn adds an insert column initialized by evaluating a CQL function.
+func (b *InsertBuilder) FuncColumn(column string, fn *Func) *InsertBuilder {
+	b.columns = append(b.columns, initializer{
+		column: column,
+		value:  fn,
+	})
 	return b
 }
 

--- a/qb/insert_test.go
+++ b/qb/insert_test.go
@@ -35,6 +35,18 @@ func TestInsertBuilder(t *testing.T) {
 			S: "INSERT INTO cycling.cyclist_name (id,user_uuid,firstname,stars) VALUES (?,?,?,?) ",
 			N: []string{"id", "user_uuid", "firstname", "stars"},
 		},
+		// Add a named column
+		{
+			B: Insert("cycling.cyclist_name").Columns("id", "user_uuid", "firstname").NamedColumn("stars", "stars_name"),
+			S: "INSERT INTO cycling.cyclist_name (id,user_uuid,firstname,stars) VALUES (?,?,?,?) ",
+			N: []string{"id", "user_uuid", "firstname", "stars_name"},
+		},
+		// Add a literal column
+		{
+			B: Insert("cycling.cyclist_name").Columns("id", "user_uuid", "firstname").LitColumn("stars", "stars_lit"),
+			S: "INSERT INTO cycling.cyclist_name (id,user_uuid,firstname,stars) VALUES (?,?,?,stars_lit) ",
+			N: []string{"id", "user_uuid", "firstname"},
+		},
 		// Add TTL
 		{
 			B: Insert("cycling.cyclist_name").Columns("id", "user_uuid", "firstname").TTL(),

--- a/qb/token.go
+++ b/qb/token.go
@@ -75,6 +75,6 @@ func (t TokenBuilder) cmp(op op, names []string) Cmp {
 	return Cmp{
 		op:     op,
 		column: fmt.Sprint("token(", strings.Join(t, ","), ")"),
-		fn:     Fn("token", s...),
+		value:  Fn("token", s...),
 	}
 }

--- a/qb/update_test.go
+++ b/qb/update_test.go
@@ -36,6 +36,12 @@ func TestUpdateBuilder(t *testing.T) {
 			S: "UPDATE cycling.cyclist_name SET id=?,user_uuid=?,firstname=?,stars=? WHERE id=? ",
 			N: []string{"id", "user_uuid", "firstname", "stars", "expr"},
 		},
+		// Add SET literal
+		{
+			B: Update("cycling.cyclist_name").SetLit("user_uuid", "literal_uuid").Where(w).Set("stars"),
+			S: "UPDATE cycling.cyclist_name SET user_uuid=literal_uuid,stars=? WHERE id=? ",
+			N: []string{"stars", "expr"},
+		},
 		// Add SET SetFunc
 		{
 			B: Update("cycling.cyclist_name").SetFunc("user_uuid", Fn("someFunc", "param_0", "param_1")).Where(w).Set("stars"),

--- a/qb/update_test.go
+++ b/qb/update_test.go
@@ -60,6 +60,12 @@ func TestUpdateBuilder(t *testing.T) {
 			S: "UPDATE cycling.cyclist_name SET total=total+? WHERE id=? ",
 			N: []string{"inc", "expr"},
 		},
+		// Add SET AddLit
+		{
+			B: Update("cycling.cyclist_name").AddLit("total", "1").Where(w),
+			S: "UPDATE cycling.cyclist_name SET total=total+1 WHERE id=? ",
+			N: []string{"expr"},
+		},
 		// Add SET Remove
 		{
 			B: Update("cycling.cyclist_name").Remove("total").Where(w),
@@ -71,6 +77,12 @@ func TestUpdateBuilder(t *testing.T) {
 			B: Update("cycling.cyclist_name").RemoveNamed("total", "dec").Where(w),
 			S: "UPDATE cycling.cyclist_name SET total=total-? WHERE id=? ",
 			N: []string{"dec", "expr"},
+		},
+		// Add SET RemoveLit
+		{
+			B: Update("cycling.cyclist_name").RemoveLit("total", "1").Where(w),
+			S: "UPDATE cycling.cyclist_name SET total=total-1 WHERE id=? ",
+			N: []string{"expr"},
 		},
 		// Add WHERE
 		{

--- a/qb/value.go
+++ b/qb/value.go
@@ -1,0 +1,37 @@
+package qb
+
+import "bytes"
+
+// value is a CQL value expression for use in an initializer, assignment, or comparison.
+type value interface {
+	// clone produces a clone of this value. Writes to the original and the clone are independent.
+	// It also marks a type as implementing the value interface.
+	clone() value
+	// writeCql writes the bytes for this value to the buffer and returns the list of names of
+	// parameters which need substitution.
+	writeCql(cql *bytes.Buffer) (names []string)
+}
+
+// param is a named CQL '?' parameter.
+type param string
+
+func (p param) clone() value {
+	return p
+}
+
+func (p param) writeCql(cql *bytes.Buffer) (names []string) {
+	cql.WriteByte('?')
+	return []string{string(p)}
+}
+
+// lit is a literal CQL value.
+type lit string
+
+func (l lit) clone() value {
+	return l
+}
+
+func (l lit) writeCql(cql *bytes.Buffer) (names []string) {
+	cql.WriteString(string(l))
+	return []string{}
+}


### PR DESCRIPTION
This adds *Lit variants of the Eq, Gt, Lt, etc comparison methods,
permitting convenient comparison against known constants.

Restructure Cmp.writeCql to avoid appends + named-parameter return for
clarity, which also reduces BenchmarkCmp-8 from 612 ns/op to 555 ns/op.