### PR TITLE
Add ColumnAs for 'SELECT col AS name' queries.

### DIFF
--- a/qb/select.go
+++ b/qb/select.go
@@ -115,10 +115,9 @@ func (b *SelectBuilder) Columns(columns ...string) *SelectBuilder {
 	return b
 }
 
-// ColumnAs adds a result column with a custom name to the query.
-func (b *SelectBuilder) ColumnAs(column, name string) *SelectBuilder {
-	b.columns = append(b.columns, column+" AS "+name)
-	return b
+// As is a helper for adding a column AS name result column to the query.
+func As(column, name string) string {
+	return column + " AS " + name
 }
 
 // Distinct sets DISTINCT clause on the query.

--- a/qb/select.go
+++ b/qb/select.go
@@ -115,6 +115,12 @@ func (b *SelectBuilder) Columns(columns ...string) *SelectBuilder {
 	return b
 }
 
+// ColumnAs adds a result column with a custom name to the query.
+func (b *SelectBuilder) ColumnAs(column, name string) *SelectBuilder {
+	b.columns = append(b.columns, column+" AS "+name)
+	return b
+}
+
 // Distinct sets DISTINCT clause on the query.
 func (b *SelectBuilder) Distinct(columns ...string) *SelectBuilder {
 	b.distinct = append(b.distinct, columns...)

--- a/qb/select_test.go
+++ b/qb/select_test.go
@@ -28,6 +28,11 @@ func TestSelectBuilder(t *testing.T) {
 			B: Select("cycling.cyclist_name").Columns("id", "user_uuid", "firstname"),
 			S: "SELECT id,user_uuid,firstname FROM cycling.cyclist_name ",
 		},
+		// Add a SELECT AS column.
+		{
+			B: Select("cycling.cyclist_name").Columns("id", "user_uuid").ColumnAs("firstname", "name"),
+			S: "SELECT id,user_uuid,firstname AS name FROM cycling.cyclist_name ",
+		},
 		// Basic test for select distinct
 		{
 			B: Select("cycling.cyclist_name").Distinct("id"),

--- a/qb/select_test.go
+++ b/qb/select_test.go
@@ -28,9 +28,9 @@ func TestSelectBuilder(t *testing.T) {
 			B: Select("cycling.cyclist_name").Columns("id", "user_uuid", "firstname"),
 			S: "SELECT id,user_uuid,firstname FROM cycling.cyclist_name ",
 		},
-		// Add a SELECT AS column.
+		// Add a SELECT AS column
 		{
-			B: Select("cycling.cyclist_name").Columns("id", "user_uuid").ColumnAs("firstname", "name"),
+			B: Select("cycling.cyclist_name").Columns("id", "user_uuid", As("firstname", "name")),
 			S: "SELECT id,user_uuid,firstname AS name FROM cycling.cyclist_name ",
 		},
 		// Basic test for select distinct


### PR DESCRIPTION
Clients could do this hackily before by manually passing "col AS name",
but it isn't clearly supported.