### PR TITLE
Do not release queries in Get/Select. Fix #25.

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -146,6 +146,7 @@ func TestExample(t *testing.T) {
 		q := gocqlx.Query(session.Query(stmt), names).BindMap(qb.M{
 			"first_name": "Patricia",
 		})
+		defer q.Release()
 
 		var p Person
 		if err := gocqlx.Get(&p, q.Query); err != nil {
@@ -165,6 +166,7 @@ func TestExample(t *testing.T) {
 		q := gocqlx.Query(session.Query(stmt), names).BindMap(qb.M{
 			"first_name": []string{"Patricia", "Igy", "Ian"},
 		})
+		defer q.Release()
 
 		var people []Person
 		if err := gocqlx.Select(&people, q.Query); err != nil {
@@ -190,6 +192,7 @@ func TestExample(t *testing.T) {
 			ToCql()
 
 		q := gocqlx.Query(session.Query(stmt), names).BindStruct(p)
+		defer q.Release()
 
 		var people []Person
 		if err := gocqlx.Select(&people, q.Query); err != nil {


### PR DESCRIPTION
Releasing query objects in Get/Select could easily lead to
double-releases, which can cause dangerous and tricky data races.