### PR TITLE
Avoid one allocation when binding structs

### DIFF
--- a/queryx.go
+++ b/queryx.go
@@ -134,21 +134,22 @@ func bindStructArgs(names []string, arg0 interface{}, arg1 map[string]interface{
 		v = v.Elem()
 	}
 
-	fields := m.TraversalsByName(v.Type(), names)
-	for i, t := range fields {
+	err := m.TraversalsByNameFunc(v.Type(), names, func(i int, t []int) error {
 		if len(t) != 0 {
 			val := reflectx.FieldByIndexesReadOnly(v, t)
 			arglist = append(arglist, val.Interface())
 		} else {
 			val, ok := arg1[names[i]]
 			if !ok {
-				return arglist, fmt.Errorf("could not find name %q in %#v and %#v", names[i], arg0, arg1)
+				return fmt.Errorf("could not find name %q in %#v and %#v", names[i], arg0, arg1)
 			}
 			arglist = append(arglist, val)
 		}
-	}
 
-	return arglist, nil
+		return nil
+	})
+
+	return arglist, err
 }
 
 // BindMap binds query named parameters using map.


### PR DESCRIPTION
This speeds up binding structs by using the new TraversalsByNameFunc introduced in jmoiron/sqlx#358, which avoids allocating a slice.

```
name          old time/op    new time/op    delta
BindStruct-8     519ns ± 2%     400ns ± 2%  -22.97%  (p=0.000 n=10+10)

name          old alloc/op   new alloc/op   delta
BindStruct-8      224B ± 0%      128B ± 0%  -42.86%  (p=0.000 n=10+10)

name          old allocs/op  new allocs/op  delta
BindStruct-8      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=10+10)
```