### PR TITLE
Fix query order when using ttl and unique

### DIFF
--- a/qb/insert.go
+++ b/qb/insert.go
@@ -45,11 +45,10 @@ func (b *InsertBuilder) ToCql() (stmt string, names []string) {
 	placeholders(&cql, len(b.columns))
 	cql.WriteString(") ")
 
-	names = append(names, b.using.writeCql(&cql)...)
-
 	if b.unique {
 		cql.WriteString("IF NOT EXISTS ")
 	}
+	names = append(names, b.using.writeCql(&cql)...)
 
 	stmt = cql.String()
 	return


### PR DESCRIPTION
Correctly builds a query when using TTL and Unique. Current version generates invalid CQL statement.

Example:
qb.Insert("table").Columns("a", "b", "c").Unique().TTL().ToCql()

Produces:
INSERT INTO table (a,b,c) VALUES (?,?,?) USING TTL ? IF NOT EXISTS

Should produce:
INSERT INTO table (a,b,c) VALUES (?,?,?) IF NOT EXISTS USING TTL ? 