### PR TITLE
Add qb.ContainsKey to query keys in a map

### DIFF
--- a/qb/cmp.go
+++ b/qb/cmp.go
@@ -19,6 +19,7 @@ const (
 	geq
 	in
 	cnt
+	cntKey
 )
 
 // Cmp if a filtering comparator that is used in WHERE and IF clauses.
@@ -47,6 +48,8 @@ func (c Cmp) writeCql(cql *bytes.Buffer) (names []string) {
 		cql.WriteString(" IN ")
 	case cnt:
 		cql.WriteString(" CONTAINS ")
+	case cntKey:
+		cql.WriteString(" CONTAINS KEY ")
 	}
 	return c.value.writeCql(cql)
 }
@@ -267,10 +270,28 @@ func Contains(column string) Cmp {
 	}
 }
 
+// ContainsKey produces column CONTAINS KEY ?.
+func ContainsKey(column string) Cmp {
+	return Cmp{
+		op:     cntKey,
+		column: column,
+		value:  param(column),
+	}
+}
+
 // ContainsNamed produces column CONTAINS ? with a custom parameter name.
 func ContainsNamed(column, name string) Cmp {
 	return Cmp{
 		op:     cnt,
+		column: column,
+		value:  param(name),
+	}
+}
+
+// ContainsKeyNamed produces column CONTAINS KEY ? with a custom parameter name.
+func ContainsKeyNamed(column, name string) Cmp {
+	return Cmp{
+		op:     cntKey,
 		column: column,
 		value:  param(name),
 	}

--- a/qb/cmp_test.go
+++ b/qb/cmp_test.go
@@ -53,6 +53,11 @@ func TestCmp(t *testing.T) {
 			S: "cnt CONTAINS ?",
 			N: []string{"cnt"},
 		},
+		{
+			C: ContainsKey("cntKey"),
+			S: "cntKey CONTAINS KEY ?",
+			N: []string{"cntKey"},
+		},
 
 		// Custom bind names
 		{
@@ -88,6 +93,11 @@ func TestCmp(t *testing.T) {
 		{
 			C: ContainsNamed("cnt", "name"),
 			S: "cnt CONTAINS ?",
+			N: []string{"name"},
+		},
+		{
+			C: ContainsKeyNamed("cntKey", "name"),
+			S: "cntKey CONTAINS KEY ?",
 			N: []string{"name"},
 		},
 


### PR DESCRIPTION
This is needed to query the keys of a map using a secondary index like this:

    CREATE TABLE user (id uuid primary key, cities map<text, text>);
    CREATE INDEX foobar ON user (keys(cities));
    SELECT * FROM user WHERE cities CONTAINS KEY 'Paris'