### PR TITLE
fix(qb): Fixed group by generation

### DIFF
--- a/qb/select.go
+++ b/qb/select.go
@@ -10,6 +10,7 @@ package qb
 import (
 	"bytes"
 	"fmt"
+	"strings"
 )
 
 // Order specifies sorting order.
@@ -53,9 +54,7 @@ func (b *SelectBuilder) ToCql() (stmt string, names []string) {
 		cql.WriteString("DISTINCT ")
 		b.distinct.writeCql(&cql)
 	case len(b.groupBy) > 0:
-		b.groupBy.writeCql(&cql)
-		cql.WriteByte(',')
-		b.columns.writeCql(&cql)
+		cql.WriteString(strings.Join(append(b.groupBy, b.columns...), ","))
 	case len(b.columns) == 0:
 		cql.WriteByte('*')
 	default:

--- a/qb/select.go
+++ b/qb/select.go
@@ -10,7 +10,6 @@ package qb
 import (
 	"bytes"
 	"fmt"
-	"strings"
 )
 
 // Order specifies sorting order.
@@ -54,7 +53,11 @@ func (b *SelectBuilder) ToCql() (stmt string, names []string) {
 		cql.WriteString("DISTINCT ")
 		b.distinct.writeCql(&cql)
 	case len(b.groupBy) > 0:
-		cql.WriteString(strings.Join(append(b.groupBy, b.columns...), ","))
+		b.groupBy.writeCql(&cql)
+		if len(b.columns) != 0 {
+			cql.WriteByte(',')
+			b.columns.writeCql(&cql)
+		}
 	case len(b.columns) == 0:
 		cql.WriteByte('*')
 	default:

--- a/qb/select_test.go
+++ b/qb/select_test.go
@@ -54,6 +54,11 @@ func TestSelectBuilder(t *testing.T) {
 			B: Select("cycling.cyclist_name").Columns("MAX(stars) as max_stars").GroupBy("id"),
 			S: "SELECT id,MAX(stars) as max_stars FROM cycling.cyclist_name GROUP BY id ",
 		},
+		// Add GROUP BY
+		{
+			B: Select("cycling.cyclist_name").GroupBy("id"),
+			S: "SELECT id FROM cycling.cyclist_name GROUP BY id ",
+		},
 		// Add ORDER BY
 		{
 			B: Select("cycling.cyclist_name").Where(w).OrderBy("firstname", ASC),

--- a/qb/utils.go
+++ b/qb/utils.go
@@ -6,7 +6,6 @@ package qb
 
 import (
 	"bytes"
-	"strings"
 )
 
 // placeholders returns a string with count ? placeholders joined with commas.
@@ -25,5 +24,10 @@ func placeholders(cql *bytes.Buffer, count int) {
 type columns []string
 
 func (cols columns) writeCql(cql *bytes.Buffer) {
-	cql.WriteString(strings.Join(cols, ","))
+	for i, c := range cols {
+		cql.WriteString(c)
+		if i < len(cols)-1 {
+			cql.WriteByte(',')
+		}
+	}
 }

--- a/qb/utils.go
+++ b/qb/utils.go
@@ -6,6 +6,7 @@ package qb
 
 import (
 	"bytes"
+	"strings"
 )
 
 // placeholders returns a string with count ? placeholders joined with commas.
@@ -24,10 +25,5 @@ func placeholders(cql *bytes.Buffer, count int) {
 type columns []string
 
 func (cols columns) writeCql(cql *bytes.Buffer) {
-	for i, c := range cols {
-		cql.WriteString(c)
-		if i < len(cols)-1 {
-			cql.WriteByte(',')
-		}
-	}
+	cql.WriteString(strings.Join(cols, ","))
 }


### PR DESCRIPTION
* In qb/select.go, if there are no colums and the query have a GroupBy
statement then the query will be malformated.
* In qb/utils.go, refactor writeCql with a strings.Join call.

[Issue #69](https://github.com/scylladb/gocqlx/issues/69)