### PR TITLE
Update gocql version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scylladb/gocqlx
 
 require (
-	github.com/gocql/gocql v0.0.0-20180530083731-3c37daec2f4d
+	github.com/gocql/gocql v0.0.0-20181124151448-70385f88b28b
 	github.com/google/go-cmp v0.2.0
 )


### PR DESCRIPTION
Due to gocql's issue (ex. https://github.com/gocql/gocql/issues/1191), the current version of gocqlx takes too high CPU utilization.
We updated go.mod file to use the newest version of gocql.

Thanks.