### PR TITLE
Timestamps should be in milliseconds, not microseconds

### DIFF
--- a/qb/delete_test.go
+++ b/qb/delete_test.go
@@ -52,7 +52,7 @@ func TestDeleteBuilder(t *testing.T) {
 		// Add TIMESTAMP
 		{
 			B: Delete("cycling.cyclist_name").Where(w).Timestamp(time.Date(2005, 05, 05, 0, 0, 0, 0, time.UTC)),
-			S: "DELETE FROM cycling.cyclist_name USING TIMESTAMP 1115251200000000 WHERE id=? ",
+			S: "DELETE FROM cycling.cyclist_name USING TIMESTAMP 1115251200000 WHERE id=? ",
 			N: []string{"expr"},
 		},
 		{

--- a/qb/using.go
+++ b/qb/using.go
@@ -17,7 +17,7 @@ func TTL(d time.Duration) int64 {
 
 // Timestamp converts time to format expected in USING TIMESTAMP clause.
 func Timestamp(t time.Time) int64 {
-	return t.UnixNano() / 1000
+	return t.UnixNano() / time.Millisecond.Nanoseconds()
 }
 
 type using struct {


### PR DESCRIPTION
Currently timestamps seem to be converted as microseconds, which is [incorrect](https://docs.scylladb.com/getting-started/types/#timestamps) and incompatible with other tools and client implementations (e.g. cqlsh).

This PR is just an illustrative example, but I guess you might want to fix it in a more backwards compatible way.