### PR TITLE
fix gocql.Query.WithContext retrun shallow copy bug

### DIFF
--- a/queryx_wrap.go
+++ b/queryx_wrap.go
@@ -86,7 +86,7 @@ func (q *Queryx) RoutingKey(routingKey []byte) *Queryx {
 // query, queries will be canceled and return once the context is
 // canceled.
 func (q *Queryx) WithContext(ctx context.Context) *Queryx {
-	q.Query.WithContext(ctx)
+	q.Query = q.Query.WithContext(ctx)
 	return q
 }
 


### PR DESCRIPTION
fix gocql.Query.WithContext retrun shallow copy bug