### PR TITLE
inherit the mapper of query

### DIFF
--- a/queryx.go
+++ b/queryx.go
@@ -209,7 +209,9 @@ func (q *Queryx) Get(dest interface{}) error {
 	if q.err != nil {
 		return q.err
 	}
-	return Iter(q.Query).Get(dest)
+	iter := Iter(q.Query)
+	iter.Mapper = q.Mapper
+	return iter.Get(dest)
 }
 
 // GetRelease calls Get and releases the query, a released query cannot be


### PR DESCRIPTION
The temporary `Iter` should inherit the mapper from the query, otherwise it would hard-code as `DefaultMapper`, ignoring the actual mapper.