### PR TITLE
iterx: paging iteration working

### DIFF
--- a/.travis_start_db.sh
+++ b/.travis_start_db.sh
@@ -4,7 +4,7 @@ set -e
 case ${DB} in
 
 scylla)
-    sudo curl -o /etc/apt/sources.list.d/scylla.list -L http://repositories.scylladb.com/scylla/repo/20fc70b18261bf832cf8e0733a27979c/ubuntu/scylladb-2.1-trusty.list
+    sudo curl -o /etc/apt/sources.list.d/scylla.list -L http://repositories.scylladb.com/scylla/repo/20fc70b18261bf832cf8e0733a27979c/ubuntu/scylladb-3.0-trusty.list
     sudo apt-get -qq update
     sudo apt-get install -y --allow-unauthenticated scylla-server
     sudo /usr/bin/scylla --options-file /etc/scylla/scylla.yaml ${SCYLLA_OPTS} &> /tmp/scylla.log &

--- a/iterx.go
+++ b/iterx.go
@@ -80,11 +80,6 @@ func (iter *Iterx) scanAny(dest interface{}, structOnly bool) bool {
 		return false
 	}
 
-	// no results or query error
-	if iter.Iter.NumRows() == 0 {
-		return false
-	}
-
 	base := reflectx.Deref(value.Type())
 	scannable := isScannable(base)
 
@@ -132,11 +127,6 @@ func (iter *Iterx) scanAll(dest interface{}, structOnly bool) bool {
 		return false
 	}
 
-	// no results or query error
-	if iter.Iter.NumRows() == 0 {
-		return false
-	}
-
 	slice, err := baseType(value.Type(), reflect.Slice)
 	if err != nil {
 		iter.err = err
@@ -180,7 +170,7 @@ func (iter *Iterx) scanAll(dest interface{}, structOnly bool) bool {
 
 		// allocate memory for the page data
 		if !alloc {
-			v = reflect.MakeSlice(slice, 0, iter.Iter.NumRows())
+			v = reflect.MakeSlice(slice, 0, iter.NumRows())
 			alloc = true
 		}
 
@@ -209,11 +199,6 @@ func (iter *Iterx) StructScan(dest interface{}) bool {
 	v := reflect.ValueOf(dest)
 	if v.Kind() != reflect.Ptr {
 		iter.err = errors.New("must pass a pointer, not a value, to StructScan destination")
-		return false
-	}
-
-	// no results or query error
-	if iter.Iter.NumRows() == 0 {
 		return false
 	}
 


### PR DESCRIPTION
We used to rely upon NumRows to determine if there are
new pages available. This is not correct and the needed
data to do this is not exposed by the gocql driver.

We simply remove these checks and let the driver decide.