### PR TITLE
Add support for BYPASS CACHE

### DIFF
--- a/qb/select.go
+++ b/qb/select.go
@@ -40,6 +40,7 @@ type SelectBuilder struct {
 	limit             uint
 	limitPerPartition uint
 	allowFiltering    bool
+	bypassCache       bool
 	json              bool
 }
 
@@ -107,6 +108,10 @@ func (b *SelectBuilder) ToCql() (stmt string, names []string) {
 
 	if b.allowFiltering {
 		cql.WriteString("ALLOW FILTERING ")
+	}
+
+	if b.bypassCache {
+		cql.WriteString("BYPASS CACHE ")
 	}
 
 	stmt = cql.String()
@@ -177,6 +182,15 @@ func (b *SelectBuilder) LimitPerPartition(limit uint) *SelectBuilder {
 // AllowFiltering sets a ALLOW FILTERING clause on the query.
 func (b *SelectBuilder) AllowFiltering() *SelectBuilder {
 	b.allowFiltering = true
+	return b
+}
+
+// BypassCache sets a BYPASS CACHE clause on the query.
+//
+// BYPASS CACHE is a feature specific to ScyllaDB.
+// See https://docs.scylladb.com/getting-started/dml/#bypass-cache
+func (b *SelectBuilder) BypassCache() *SelectBuilder {
+	b.bypassCache = true
 	return b
 }
 

--- a/qb/select_test.go
+++ b/qb/select_test.go
@@ -128,6 +128,18 @@ func TestSelectBuilder(t *testing.T) {
 			S: "SELECT * FROM cycling.cyclist_name WHERE id=? ALLOW FILTERING ",
 			N: []string{"expr"},
 		},
+		// Add ALLOW FILTERING and BYPASS CACHE
+		{
+			B: Select("cycling.cyclist_name").Where(w).AllowFiltering().BypassCache(),
+			S: "SELECT * FROM cycling.cyclist_name WHERE id=? ALLOW FILTERING BYPASS CACHE ",
+			N: []string{"expr"},
+		},
+		// Add BYPASS CACHE
+		{
+			B: Select("cycling.cyclist_name").Where(w).BypassCache(),
+			S: "SELECT * FROM cycling.cyclist_name WHERE id=? BYPASS CACHE ",
+			N: []string{"expr"},
+		},
 		// Add COUNT all
 		{
 			B: Select("cycling.cyclist_name").CountAll().Where(Gt("stars")),


### PR DESCRIPTION
This commit adds support for BYPASS CACHE extension that is present in
ScyllaDB since 3.1 / 2019.1.1.

https://docs.scylladb.com/getting-started/dml/#bypass-cache