### PR TITLE
Improve assign in qb package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Go vendor dir
 vendor
+
+# GoLand IDE
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,5 @@
 
 # Go vendor dir
 vendor
-
 # GoLand IDE
 .idea/

--- a/qb/select.go
+++ b/qb/select.go
@@ -132,7 +132,11 @@ func (b *SelectBuilder) Json() *SelectBuilder {
 
 // Columns adds result columns to the query.
 func (b *SelectBuilder) Columns(columns ...string) *SelectBuilder {
-	b.columns = append(b.columns, columns...)
+	if len(b.columns) == 0 {
+		b.columns = columns
+	} else {
+		b.columns = append(b.columns, columns...)
+	}
 	return b
 }
 
@@ -143,21 +147,33 @@ func As(column, name string) string {
 
 // Distinct sets DISTINCT clause on the query.
 func (b *SelectBuilder) Distinct(columns ...string) *SelectBuilder {
-	b.distinct = append(b.distinct, columns...)
+	if len(b.where) == 0 {
+		b.distinct = columns
+	} else {
+		b.distinct = append(b.distinct, columns...)
+	}
 	return b
 }
 
 // Where adds an expression to the WHERE clause of the query. Expressions are
 // ANDed together in the generated CQL.
 func (b *SelectBuilder) Where(w ...Cmp) *SelectBuilder {
-	b.where = append(b.where, w...)
+	if len(b.where) == 0 {
+		b.where = w
+	} else {
+		b.where = append(b.where, w...)
+	}
 	return b
 }
 
 // GroupBy sets GROUP BY clause on the query. Columns must be a primary key,
 // this will automatically add the the columns as first selectors.
 func (b *SelectBuilder) GroupBy(columns ...string) *SelectBuilder {
-	b.groupBy = append(b.groupBy, columns...)
+	if len(b.groupBy) == 0 {
+		b.groupBy = columns
+	} else {
+		b.groupBy = append(b.groupBy, columns...)
+	}
 	return b
 }
 

--- a/qb/select_bench_test.go
+++ b/qb/select_bench_test.go
@@ -9,6 +9,23 @@ import "testing"
 func BenchmarkSelectBuilder(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Select("cycling.cyclist_name").Columns("id", "user_uuid", "firstname", "stars").Where(Eq("id")).ToCql()
+		Select("cycling.cyclist_name").
+			Columns("id", "user_uuid", "firstname", "surname", "stars").
+			Where(Eq("id")).
+			ToCql()
+	}
+}
+
+func BenchmarkSelectBuildAssign(b *testing.B) {
+	b.ResetTimer()
+	cols := []string{
+		"id", "user_uuid", "firstname",
+		"surname", "stars",
+	}
+	for i := 0; i < b.N; i++ {
+		Select("cycling.cyclist_name").
+			Columns(cols...).
+			Where(Eq("id")).
+			ToCql()
 	}
 }

--- a/qb/token.go
+++ b/qb/token.go
@@ -14,7 +14,7 @@ type TokenBuilder []string
 
 // Token creates a new TokenBuilder.
 func Token(columns ...string) TokenBuilder {
-	return TokenBuilder(columns)
+	return columns
 }
 
 // Eq produces token(column)=token(?).

--- a/qb/update.go
+++ b/qb/update.go
@@ -212,14 +212,22 @@ func (b *UpdateBuilder) removeValue(column string, value value) *UpdateBuilder {
 // Where adds an expression to the WHERE clause of the query. Expressions are
 // ANDed together in the generated CQL.
 func (b *UpdateBuilder) Where(w ...Cmp) *UpdateBuilder {
-	b.where = append(b.where, w...)
+	if len(b.where) == 0 {
+		b.where = w
+	} else {
+		b.where = append(b.where, w...)
+	}
 	return b
 }
 
 // If adds an expression to the IF clause of the query. Expressions are ANDed
 // together in the generated CQL.
 func (b *UpdateBuilder) If(w ...Cmp) *UpdateBuilder {
-	b._if = append(b._if, w...)
+	if len(b._if) == 0 {
+		b._if = w
+	} else {
+		b._if = append(b._if, w...)
+	}
 	return b
 }
 


### PR DESCRIPTION
Changed some core functions to avoid extra allocation performed during assigment, for instance:
Instead of recreate the slice in this way:
```
// Columns adds result columns to the query.
func (b *SelectBuilder) Columns(columns ...string) *SelectBuilder {
	b.columns = append(b.columns, columns...)
	return b
}
```

we can forwad it:

```
// Columns adds result columns to the query.
func (b *SelectBuilder) Columns(columns ...string) *SelectBuilder {
	if len(b.columns) == 0 {
		b.columns = columns
	} else {
		b.columns = append(b.columns, columns...)
	}
	return b
}
```