### PR TITLE
Add not equal comparators (!=)

### DIFF
--- a/qb/cmp.go
+++ b/qb/cmp.go
@@ -21,6 +21,7 @@ const (
 	cnt
 	cntKey
 	like
+	ne
 )
 
 // Cmp if a filtering comparator that is used in WHERE and IF clauses.
@@ -53,6 +54,8 @@ func (c Cmp) writeCql(cql *bytes.Buffer) (names []string) {
 		cql.WriteString(" CONTAINS KEY ")
 	case like:
 		cql.WriteString(" LIKE ")
+	case ne:
+		cql.WriteString("!=")
 	}
 	return c.value.writeCql(cql)
 }
@@ -100,6 +103,54 @@ func EqLit(column, literal string) Cmp {
 func EqFunc(column string, fn *Func) Cmp {
 	return Cmp{
 		op:     eq,
+		column: column,
+		value:  fn,
+	}
+}
+
+// Ne produces column!=?.
+func Ne(column string) Cmp {
+	return Cmp{
+		op:     ne,
+		column: column,
+		value:  param(column),
+	}
+}
+
+// NeTuple produces column!=(?,?,...) with count number of placeholders.
+func NeTuple(column string, count int) Cmp {
+	return Cmp{
+		op:     ne,
+		column: column,
+		value: tupleParam{
+			param: param(column),
+			count: count,
+		},
+	}
+}
+
+// NeNamed produces column!=? with a custom parameter name.
+func NeNamed(column, name string) Cmp {
+	return Cmp{
+		op:     ne,
+		column: column,
+		value:  param(name),
+	}
+}
+
+// NeLit produces column!=literal and does not add a parameter to the query.
+func NeLit(column, literal string) Cmp {
+	return Cmp{
+		op:     ne,
+		column: column,
+		value:  lit(literal),
+	}
+}
+
+// NeFunc produces column!=someFunc(?...).
+func NeFunc(column string, fn *Func) Cmp {
+	return Cmp{
+		op:     ne,
 		column: column,
 		value:  fn,
 	}

--- a/qb/cmp_test.go
+++ b/qb/cmp_test.go
@@ -103,6 +103,16 @@ func TestCmp(t *testing.T) {
 			S: "like LIKE (?,?)",
 			N: []string{"like_0", "like_1"},
 		},
+		{
+			C: Ne("ne"),
+			S: "ne!=?",
+			N: []string{"ne"},
+		},
+		{
+			C: NeTuple("ne", 3),
+			S: "ne!=(?,?,?)",
+			N: []string{"ne_0", "ne_1", "ne_2"},
+		},
 
 		// Custom bind names
 		{
@@ -145,6 +155,11 @@ func TestCmp(t *testing.T) {
 			S: "cntKey CONTAINS KEY ?",
 			N: []string{"name"},
 		},
+		{
+			C: NeNamed("ne", "name"),
+			S: "ne!=?",
+			N: []string{"name"},
+		},
 
 		// Literals
 		{
@@ -174,6 +189,10 @@ func TestCmp(t *testing.T) {
 		{
 			C: ContainsLit("cnt", "litval"),
 			S: "cnt CONTAINS litval",
+		},
+		{
+			C: NeLit("ne", "litval"),
+			S: "ne!=litval",
 		},
 
 		// Functions
@@ -213,6 +232,11 @@ func TestCmp(t *testing.T) {
 			C: GtOrEqFunc("eq", MaxTimeuuid("arg0")),
 			S: "eq>=maxTimeuuid(?)",
 			N: []string{"arg0"},
+		},
+		{
+			C: NeFunc("ne", Fn("fn", "arg0", "arg1", "arg2")),
+			S: "ne!=fn(?,?,?)",
+			N: []string{"arg0", "arg1", "arg2"},
 		},
 	}
 


### PR DESCRIPTION
The `qb.Cmp` lacks `not equal` methods related to the operator `!=`
even though the documentation
https://docs.scylladb.com/getting-started/dml/#select-statement mentions
it.

Closes: #114

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>