### PR TITLE
Test with Go 1.12 and 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: true
 language: go
 go:
-  - 1.11.x
+  - stable
+  - oldstable
 
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,4 @@ get-deps:
 .PHONY: get-tools
 get-tools:
 	@echo "==> Installing tools at $(GOBIN)..."
-	@$(call dl_tgz,golangci-lint,https://github.com/golangci/golangci-lint/releases/download/v1.10.2/golangci-lint-1.10.2-linux-amd64.tar.gz)
+	@$(call dl_tgz,golangci-lint,https://github.com/golangci/golangci-lint/releases/download/v1.21.0/golangci-lint-1.21.0-linux-amd64.tar.gz)

--- a/gocqlxtest/gocqlxtest.go
+++ b/gocqlxtest/gocqlxtest.go
@@ -24,14 +24,14 @@ var (
 	flagRetry        = flag.Int("retries", 5, "number of times to retry queries")
 	flagCompressTest = flag.String("compressor", "", "compressor to use")
 	flagTimeout      = flag.Duration("gocql.timeout", 5*time.Second, "sets the connection `timeout` for all operations")
-
-	clusterHosts []string
 )
 
 func init() {
-	flag.Parse()
-	clusterHosts = strings.Split(*flagCluster, ",")
 	log.SetFlags(log.Lshortfile | log.LstdFlags)
+}
+
+func clusterHosts() []string {
+	return strings.Split(*flagCluster, ",")
 }
 
 var initOnce sync.Once
@@ -43,7 +43,7 @@ func CreateSession(tb testing.TB) *gocql.Session {
 }
 
 func createCluster() *gocql.ClusterConfig {
-	cluster := gocql.NewCluster(clusterHosts...)
+	cluster := gocql.NewCluster(clusterHosts()...)
 	cluster.ProtoVersion = *flagProto
 	cluster.CQLVersion = *flagCQL
 	cluster.Timeout = *flagTimeout


### PR DESCRIPTION
Support last two versions of Go, similar to gocql. We also need to
remove the flag.Parse() call because of the change in Go 1.13:

> Testing flags are now registered in the new Init function, which is
> invoked by the generated main function for the test. As a result,
> testing flags are now only registered when running a test binary, and
> packages that call flag.Parse during package initialization may cause
> tests to fail.