### PR TITLE
Add DefaultUnsafe global

### DIFF
--- a/iterx.go
+++ b/iterx.go
@@ -13,6 +13,10 @@ import (
 	"github.com/scylladb/go-reflectx"
 )
 
+// DefaultUnsafe enables the behavior of forcing the iterator to ignore
+// missing fields for all queries. See Unsafe below for more information.
+var DefaultUnsafe bool
+
 // Get is a convenience function for creating iterator and calling Get.
 //
 // DEPRECATED use Queryx.Get or Queryx.GetRelease.
@@ -208,7 +212,7 @@ func (iter *Iterx) StructScan(dest interface{}) bool {
 
 		iter.fields = m.TraversalsByName(v.Type(), columns)
 		// if we are not unsafe and are missing fields, return an error
-		if !iter.unsafe {
+		if !iter.unsafe && !DefaultUnsafe {
 			if f, err := missingFields(iter.fields); err != nil {
 				iter.err = fmt.Errorf("missing destination name %q in %T", columns[f], dest)
 				return false

--- a/iterx_test.go
+++ b/iterx_test.go
@@ -276,6 +276,22 @@ func TestUnsafe(t *testing.T) {
 			t.Fatal("select failed")
 		}
 	})
+
+	t.Run("DefaultUnsafe select", func(t *testing.T) {
+		gocqlx.DefaultUnsafe = true
+		defer func() { gocqlx.DefaultUnsafe = true }()
+		var v []UnsafeTable
+		i := gocqlx.Iter(session.Query(`SELECT * FROM unsafe_table`))
+		if err := i.Select(&v); err != nil {
+			t.Fatal(err)
+		}
+		if len(v) != 1 {
+			t.Fatal("select failed")
+		}
+		if v[0].Testtext != "test" {
+			t.Fatal("select failed")
+		}
+	})
 }
 
 func TestNotFound(t *testing.T) {


### PR DESCRIPTION
As discussed in #130 here's a simple option to enable Iterx's `Unsafe()` behavior globally.