### PR TITLE
table: fix data race in select builder usage

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -45,7 +45,8 @@ func New(m Metadata) *Table { // nolint: gocritic
 	for _, k := range m.SortKey {
 		t.primaryKeyCmp = append(t.primaryKeyCmp, qb.Eq(k))
 	}
-	t.partKeyCmp = t.primaryKeyCmp[:len(t.metadata.PartKey)]
+	t.partKeyCmp = make([]qb.Cmp, len(m.PartKey))
+	copy(t.partKeyCmp, t.primaryKeyCmp[:len(t.metadata.PartKey)])
 
 	// prepare get stmt
 	t.get.stmt, t.get.names = qb.Select(m.Name).Where(t.primaryKeyCmp...).ToCql()


### PR DESCRIPTION
When table is used with `SelectBuilder` it triggers data race on `Where` condition usage.

This PR copies underlining slices on table creation to allow safe concurrent usage of the table.