### PR TITLE
gocqlx/table/Table: support timestamp at the granularity of batch statements

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -105,10 +105,20 @@ func (t *Table) Insert() (stmt string, names []string) {
 
 // Update returns update by primary key statement.
 func (t *Table) Update(columns ...string) (stmt string, names []string) {
-	return qb.Update(t.metadata.Name).Set(columns...).Where(t.primaryKeyCmp...).ToCql()
+	return t.UpdateBuilder(columns...).ToCql()
+}
+
+// UpdateBuilder returns a builder initialised to update by primary key statement.
+func (t *Table) UpdateBuilder(columns ...string) *qb.UpdateBuilder {
+	return qb.Update(t.metadata.Name).Set(columns...).Where(t.primaryKeyCmp...)
 }
 
 // Delete returns delete by primary key statement.
 func (t *Table) Delete(columns ...string) (stmt string, names []string) {
-	return qb.Delete(t.metadata.Name).Columns(columns...).Where(t.primaryKeyCmp...).ToCql()
+	return t.DeleteBuilder(columns...).ToCql()
+}
+
+// DeleteBuilder returns a builder initialised to delete by primary key statement.
+func (t *Table) DeleteBuilder(columns ...string) *qb.DeleteBuilder {
+	return qb.Delete(t.metadata.Name).Columns(columns...).Where(t.primaryKeyCmp...)
 }

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -171,6 +171,17 @@ func TestTableUpdate(t *testing.T) {
 			t.Error(diff, names)
 		}
 	}
+
+	// run UpdateBuilder on the same data set
+	for _, test := range table {
+		stmt, names := New(test.M).UpdateBuilder(test.C...).ToCql()
+		if diff := cmp.Diff(test.S, stmt); diff != "" {
+			t.Error(diff)
+		}
+		if diff := cmp.Diff(test.N, names); diff != "" {
+			t.Error(diff, names)
+		}
+	}
 }
 
 func TestTableDelete(t *testing.T) {
@@ -213,6 +224,17 @@ func TestTableDelete(t *testing.T) {
 
 	for _, test := range table {
 		stmt, names := New(test.M).Delete(test.C...)
+		if diff := cmp.Diff(test.S, stmt); diff != "" {
+			t.Error(diff)
+		}
+		if diff := cmp.Diff(test.N, names); diff != "" {
+			t.Error(diff, names)
+		}
+	}
+
+	// run DeleteBuilder on the same data set
+	for _, test := range table {
+		stmt, names := New(test.M).DeleteBuilder(test.C...).ToCql()
 		if diff := cmp.Diff(test.S, stmt); diff != "" {
 			t.Error(diff)
 		}


### PR DESCRIPTION
I'd like to add some public functions to expose CRUD query builders,  which is similar as
func (t *Table) SelectBuilder(columns ...string) *qb.SelectBuilder {
to enable timestamp at the granularity of batch statements.