### PR TITLE
table: Added PrimaryKeyCmp() which  returns copy of table's primaryKe…

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -63,6 +63,13 @@ func (t *Table) Metadata() Metadata {
 	return t.metadata
 }
 
+// PrimaryKeyCmp returns copy of table's primaryKeyCmp.
+func (t *Table) PrimaryKeyCmp() []qb.Cmp {
+	primaryKeyCmp := make([]qb.Cmp, len(t.primaryKeyCmp))
+	copy(primaryKeyCmp, t.primaryKeyCmp)
+	return primaryKeyCmp
+}
+
 // Name returns table name.
 func (t *Table) Name() string {
 	return t.metadata.Name


### PR DESCRIPTION
Added PrimaryKeyCmp returns copy of table's primaryKeyCmp.
https://github.com/scylladb/gocqlx/issues/138
