### PR TITLE
Add Session wrapper

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -1,8 +1,25 @@
+// Copyright (C) 2017 ScyllaDB
+// Use of this source code is governed by a ALv2-style
+// license that can be found in the LICENSE file.
+
 package gocqlx_test
 
 import (
+	"github.com/gocql/gocql"
 	"github.com/scylladb/gocqlx"
+	"github.com/scylladb/gocqlx/qb"
 )
+
+func ExampleSession() {
+	cluster := gocql.NewCluster("host")
+	session, err := gocqlx.WrapSession(cluster.CreateSession())
+	if err != nil {
+		// handle error
+	}
+
+	builder := qb.Select("foo")
+	session.Query(builder.ToCql())
+}
 
 func ExampleUDT() {
 	// Just add gocqlx.UDT to a type, no need to implement marshalling functions

--- a/example_test.go
+++ b/example_test.go
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
     PRIMARY KEY(first_name, last_name)
 )`
 
-	if err := ExecStmt(session, personSchema); err != nil {
+	if err := session.ExecStmt(personSchema); err != nil {
 		t.Fatal("create table:", err)
 	}
 
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
 	// Insert, bind data from struct.
 	{
 		stmt, names := qb.Insert("gocqlx_test.person").Columns("first_name", "last_name", "email").ToCql()
-		q := gocqlx.Query(session.Query(stmt), names).BindStruct(p)
+		q := session.Query(stmt, names).BindStruct(p)
 
 		if err := q.ExecRelease(); err != nil {
 			t.Fatal(err)
@@ -63,9 +63,9 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
 			TTL(86400 * time.Second).
 			Timestamp(time.Now()).
 			ToCql()
+		q := session.Query(stmt, names).BindStruct(p)
 
-		err := gocqlx.Query(session.Query(stmt), names).BindStruct(p).ExecRelease()
-		if err != nil {
+		if err := q.ExecRelease(); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -78,7 +78,7 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
 			Set("email").
 			Where(qb.Eq("first_name"), qb.Eq("last_name")).
 			ToCql()
-		q := gocqlx.Query(session.Query(stmt), names).BindStruct(p)
+		q := session.Query(stmt, names).BindStruct(p)
 
 		if err := q.ExecRelease(); err != nil {
 			t.Fatal(err)
@@ -91,7 +91,7 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
 			AddNamed("email", "new_email").
 			Where(qb.Eq("first_name"), qb.Eq("last_name")).
 			ToCql()
-		q := gocqlx.Query(session.Query(stmt), names).BindStructMap(p, qb.M{
+		q := session.Query(stmt, names).BindStructMap(p, qb.M{
 			"new_email": []string{"patricia2.citzen@gocqlx_test.com", "patricia3.citzen@gocqlx_test.com"},
 		})
 
@@ -124,7 +124,7 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
 				[]string{"ian.citzen@gocqlx_test.com"},
 			},
 		}
-		q := gocqlx.Query(session.Query(stmt), names).BindStruct(&batch)
+		q := session.Query(stmt, names).BindStruct(&batch)
 
 		if err := q.ExecRelease(); err != nil {
 			t.Fatal(err)
@@ -136,7 +136,7 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
 		var p Person
 
 		stmt, names := qb.Select("gocqlx_test.person").Where(qb.Eq("first_name")).ToCql()
-		q := gocqlx.Query(session.Query(stmt), names).BindMap(qb.M{
+		q := session.Query(stmt, names).BindMap(qb.M{
 			"first_name": "Patricia",
 		})
 
@@ -153,7 +153,7 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
 		var people []Person
 
 		stmt, names := qb.Select("gocqlx_test.person").Where(qb.In("first_name")).ToCql()
-		q := gocqlx.Query(session.Query(stmt), names).BindMap(qb.M{
+		q := session.Query(stmt, names).BindMap(qb.M{
 			"first_name": []string{"Patricia", "Igy", "Ian"},
 		})
 
@@ -178,7 +178,7 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
 			Where(qb.Token("first_name").Gt()).
 			Limit(10).
 			ToCql()
-		q := gocqlx.Query(session.Query(stmt), names).BindStruct(p)
+		q := session.Query(stmt, names).BindStruct(p)
 
 		var people []Person
 		if err := q.SelectRelease(&people); err != nil {
@@ -202,7 +202,8 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
 			"Citizen",
 			[]string{"jane.citzen@gocqlx_test.com"},
 		}
-		q := gocqlx.Query(session.Query(stmt), names).BindStruct(p)
+		q := session.Query(stmt, names).BindStruct(p)
+
 		if err := q.ExecRelease(); err != nil {
 			t.Fatal(err)
 		}

--- a/iterx.go
+++ b/iterx.go
@@ -31,15 +31,6 @@ type Iterx struct {
 	values []interface{}
 }
 
-// Iter creates a new Iterx from gocql.Query using a default mapper.
-func Iter(q *gocql.Query) *Iterx {
-	return &Iterx{
-		Iter:   q.Iter(),
-		Mapper: DefaultMapper,
-		unsafe: DefaultUnsafe,
-	}
-}
-
 // Unsafe forces the iterator to ignore missing fields. By default when scanning
 // a struct if result row has a column that cannot be mapped to any destination
 // field an error is reported. With unsafe such columns are ignored.

--- a/mapper.go
+++ b/mapper.go
@@ -12,4 +12,6 @@ import (
 // snake case. It can be set to whatever you want, but it is encouraged to be
 // set before gocqlx is used as name-to-field mappings are cached after first
 // use on a type.
+//
+// A custom mapper can always be set per Sessionm, Query and Iter.
 var DefaultMapper = reflectx.NewMapperFunc("db", reflectx.CamelToSnakeASCII)

--- a/migrate/callback.go
+++ b/migrate/callback.go
@@ -7,7 +7,7 @@ package migrate
 import (
 	"context"
 
-	"github.com/gocql/gocql"
+	"github.com/scylladb/gocqlx"
 )
 
 // CallbackEvent specifies type of the event when calling CallbackFunc.
@@ -21,7 +21,7 @@ const (
 
 // CallbackFunc enables interrupting the migration process and executing code
 // while migrating. If error is returned the migration is aborted.
-type CallbackFunc func(ctx context.Context, session *gocql.Session, ev CallbackEvent, name string) error
+type CallbackFunc func(ctx context.Context, session gocqlx.Session, ev CallbackEvent, name string) error
 
 // Callback is called before and after each migration.
 // See CallbackFunc for details.

--- a/queryx.go
+++ b/queryx.go
@@ -90,6 +90,8 @@ type Queryx struct {
 }
 
 // Query creates a new Queryx from gocql.Query using a default mapper.
+//
+// Deprecated: Use Session API instead.
 func Query(q *gocql.Query, names []string) *Queryx {
 	return &Queryx{
 		Query:  q,
@@ -266,7 +268,9 @@ func (q *Queryx) SelectRelease(dest interface{}) error {
 // big to be loaded with Select in order to do row by row iteration.
 // See Iterx StructScan function.
 func (q *Queryx) Iter() *Iterx {
-	i := Iter(q.Query)
-	i.Mapper = q.Mapper
-	return i
+	return &Iterx{
+		Iter:   q.Query.Iter(),
+		Mapper: q.Mapper,
+		unsafe: DefaultUnsafe,
+	}
 }

--- a/session.go
+++ b/session.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2017 ScyllaDB
+// Use of this source code is governed by a ALv2-style
+// license that can be found in the LICENSE file.
+
+package gocqlx
+
+import (
+	"context"
+
+	"github.com/gocql/gocql"
+	"github.com/scylladb/go-reflectx"
+)
+
+// Session wraps gocql.Session and provides a modified Query function that
+// returns Queryx instance.
+// The original Session instance can be accessed as Session.
+// The default mapper uses `db` tag and automatically converts struct field
+// names to snake case. If needed package reflectx provides constructors
+// for other types of mappers.
+type Session struct {
+	*gocql.Session
+	Mapper *reflectx.Mapper
+}
+
+// WrapSession should be called on CreateSession() gocql function to convert
+// the created session to gocqlx.Session.
+func WrapSession(session *gocql.Session, err error) (Session, error) {
+	return Session{
+		Session: session,
+		Mapper:  DefaultMapper,
+	}, err
+}
+
+// ContextQuery is a helper function that allows to pass context when creating
+// a query, see the "Query" function .
+func (s Session) ContextQuery(ctx context.Context, stmt string, names []string) *Queryx {
+	return &Queryx{
+		Query:  s.Session.Query(stmt).WithContext(ctx),
+		Names:  names,
+		Mapper: s.Mapper,
+	}
+}
+
+// Query creates a new Queryx using the session mapper.
+// The stmt and names parameters are typically result of a query builder
+// (package qb) ToCql() function or come from table model (package table).
+// The names parameter is a list of query parameters' names and it's used for
+// binding.
+func (s Session) Query(stmt string, names []string) *Queryx {
+	return &Queryx{
+		Query:  s.Session.Query(stmt),
+		Names:  names,
+		Mapper: s.Mapper,
+	}
+}
+
+// ExecStmt creates query and executes the given statement.
+func (s Session) ExecStmt(stmt string) error {
+	return s.Query(stmt, nil).ExecRelease()
+}

--- a/table/example_test.go
+++ b/table/example_test.go
@@ -9,7 +9,6 @@ package table_test
 import (
 	"testing"
 
-	"github.com/scylladb/gocqlx"
 	. "github.com/scylladb/gocqlx/gocqlxtest"
 	"github.com/scylladb/gocqlx/qb"
 	"github.com/scylladb/gocqlx/table"
@@ -26,7 +25,7 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
     email list<text>,
     PRIMARY KEY(first_name, last_name)
 )`
-	if err := ExecStmt(session, personSchema); err != nil {
+	if err := session.ExecStmt(personSchema); err != nil {
 		t.Fatal("create table:", err)
 	}
 
@@ -58,8 +57,7 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
 			[]string{"patricia.citzen@gocqlx_test.com"},
 		}
 
-		stmt, names := personTable.Insert()
-		q := gocqlx.Query(session.Query(stmt), names).BindStruct(p)
+		q := session.Query(personTable.Insert()).BindStruct(p)
 		if err := q.ExecRelease(); err != nil {
 			t.Fatal(err)
 		}
@@ -73,8 +71,7 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
 			nil, // no email
 		}
 
-		stmt, names := personTable.Get() // you can filter columns too
-		q := gocqlx.Query(session.Query(stmt), names).BindStruct(p)
+		q := session.Query(personTable.Get()).BindStruct(p)
 		if err := q.GetRelease(&p); err != nil {
 			t.Fatal(err)
 		}
@@ -87,9 +84,7 @@ CREATE TABLE IF NOT EXISTS gocqlx_test.person (
 	{
 		var people []Person
 
-		stmt, names := personTable.Select() // you can filter columns too
-		q := gocqlx.Query(session.Query(stmt), names).BindMap(qb.M{"first_name": "Patricia"})
-
+		q := session.Query(personTable.Select()).BindMap(qb.M{"first_name": "Patricia"})
 		if err := q.SelectRelease(&people); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
With this patch we can now use gocqlx like:

```
session.Query(`SELECT * FROM struct_table`, nil).Get(&v)
```

instead of (old format):

```
gocqlx.Query(session.Query(`SELECT * FROM struct_table`), nil).Get(&v)
```

Signed-off-by: Michał Matczuk <michal@scylladb.com>