### PR TITLE
Specify explicitly that use gocqlx.Session.Qury API insteawd of the d…

### DIFF
--- a/queryx.go
+++ b/queryx.go
@@ -98,7 +98,7 @@ type Queryx struct {
 
 // Query creates a new Queryx from gocql.Query using a default mapper.
 //
-// Deprecated: Use Session API instead.
+// Deprecated: Use gocqlx.Session.Query API instead.
 func Query(q *gocql.Query, names []string) *Queryx {
 	return &Queryx{
 		Query:  q,


### PR DESCRIPTION
I thought I should use gocql.Session API....
May others are not confused so please feel free to close this PR if the refined comment doesn't make much sense.