### PR TITLE
Added shortcuts to Queryx

### DIFF
--- a/qb/batch.go
+++ b/qb/batch.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"fmt"
 	"time"
+
+	"github.com/scylladb/gocqlx/v2"
 )
 
 // BATCH reference:
@@ -62,6 +64,11 @@ func (b *BatchBuilder) ToCql() (stmt string, names []string) {
 
 	stmt = cql.String()
 	return
+}
+
+// Query returns query built on top of current BatchBuilder state.
+func (b *BatchBuilder) Query(session gocqlx.Session) *gocqlx.Queryx {
+	return session.Query(b.ToCql())
 }
 
 // Add builds the builder and adds the statement to the batch.

--- a/qb/delete.go
+++ b/qb/delete.go
@@ -10,6 +10,8 @@ package qb
 import (
 	"bytes"
 	"time"
+
+	"github.com/scylladb/gocqlx/v2"
 )
 
 // DeleteBuilder builds CQL DELETE statements.
@@ -52,6 +54,11 @@ func (b *DeleteBuilder) ToCql() (stmt string, names []string) {
 
 	stmt = cql.String()
 	return
+}
+
+// Query returns query built on top of current DeleteBuilder state.
+func (b *DeleteBuilder) Query(session gocqlx.Session) *gocqlx.Queryx {
+	return session.Query(b.ToCql())
 }
 
 // From sets the table to be deleted from.

--- a/qb/insert.go
+++ b/qb/insert.go
@@ -10,6 +10,8 @@ package qb
 import (
 	"bytes"
 	"time"
+
+	"github.com/scylladb/gocqlx/v2"
 )
 
 // initializer specifies an value for a column in an insert operation.
@@ -76,6 +78,11 @@ func (b *InsertBuilder) ToCql() (stmt string, names []string) {
 
 	stmt = cql.String()
 	return
+}
+
+// Query returns query built on top of current InsertBuilder state.
+func (b *InsertBuilder) Query(session gocqlx.Session) *gocqlx.Queryx {
+	return session.Query(b.ToCql())
 }
 
 // Into sets the INTO clause of the query.

--- a/qb/select.go
+++ b/qb/select.go
@@ -10,6 +10,8 @@ package qb
 import (
 	"bytes"
 	"fmt"
+
+	"github.com/scylladb/gocqlx/v2"
 )
 
 // Order specifies sorting order.
@@ -116,6 +118,11 @@ func (b *SelectBuilder) ToCql() (stmt string, names []string) {
 
 	stmt = cql.String()
 	return
+}
+
+// Query returns query built on top of current SelectBuilder state.
+func (b *SelectBuilder) Query(session gocqlx.Session) *gocqlx.Queryx {
+	return session.Query(b.ToCql())
 }
 
 // From sets the table to be selected from.

--- a/qb/update.go
+++ b/qb/update.go
@@ -10,6 +10,8 @@ package qb
 import (
 	"bytes"
 	"time"
+
+	"github.com/scylladb/gocqlx/v2"
 )
 
 // assignment specifies an assignment in a set operation.
@@ -71,6 +73,11 @@ func (b *UpdateBuilder) ToCql() (stmt string, names []string) {
 
 	stmt = cql.String()
 	return
+}
+
+// Query returns query built on top of current UpdateBuilder state.
+func (b *UpdateBuilder) Query(session gocqlx.Session) *gocqlx.Queryx {
+	return session.Query(b.ToCql())
 }
 
 // Table sets the table to be updated.

--- a/table/table.go
+++ b/table/table.go
@@ -4,7 +4,10 @@
 
 package table
 
-import "github.com/scylladb/gocqlx/v2/qb"
+import (
+	"github.com/scylladb/gocqlx/v2"
+	"github.com/scylladb/gocqlx/v2/qb"
+)
 
 // Metadata represents table schema.
 type Metadata struct {
@@ -99,6 +102,11 @@ func (t *Table) Select(columns ...string) (stmt string, names []string) {
 		ToCql()
 }
 
+// SelectQuery returns query which selects by partition key statement.
+func (t *Table) SelectQuery(session gocqlx.Session, columns ...string) *gocqlx.Queryx {
+	return session.Query(t.Select(columns...))
+}
+
 // SelectBuilder returns a builder initialised to select by partition key
 // statement.
 func (t *Table) SelectBuilder(columns ...string) *qb.SelectBuilder {
@@ -110,9 +118,19 @@ func (t *Table) Insert() (stmt string, names []string) {
 	return t.insert.stmt, t.insert.names
 }
 
+// InsertQuery returns query which inserts all columns.
+func (t *Table) InsertQuery(session gocqlx.Session) *gocqlx.Queryx {
+	return session.Query(t.Insert())
+}
+
 // Update returns update by primary key statement.
 func (t *Table) Update(columns ...string) (stmt string, names []string) {
 	return t.UpdateBuilder(columns...).ToCql()
+}
+
+// UpdateQuery returns query which updates by primary key.
+func (t *Table) UpdateQuery(session gocqlx.Session, columns ...string) *gocqlx.Queryx {
+	return session.Query(t.Update(columns...))
 }
 
 // UpdateBuilder returns a builder initialised to update by primary key statement.
@@ -123,6 +141,11 @@ func (t *Table) UpdateBuilder(columns ...string) *qb.UpdateBuilder {
 // Delete returns delete by primary key statement.
 func (t *Table) Delete(columns ...string) (stmt string, names []string) {
 	return t.DeleteBuilder(columns...).ToCql()
+}
+
+// DeleteQuery returns query which delete by primary key.
+func (t *Table) DeleteQuery(session gocqlx.Session, columns ...string) *gocqlx.Queryx {
+	return session.Query(t.Delete(columns...))
 }
 
 // DeleteBuilder returns a builder initialised to delete by primary key statement.


### PR DESCRIPTION
These shortucuts allows to write shorter more straightforward code.
It allows to write:

```
clusters.InsertQuery(session).BindStruct(r).ExecRelease()

qb.Select("cluster").Columns("id").Query(session)

```

instead of:

```
session.Query(clusters.Insert().ToCql()).BindStruct(r).ExecRelease()

session.Query(qb.Select("cluster").Columns("id").ToCql())
```

