### PR TITLE
migrate: Add support for Go code migrations in the middle of processing a CQL file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ bench:
 
 .PHONY: run-examples
 run-examples:
-	@go test -tags all -v -run=Example
+	@go test -tags all -v -run=Example ./...
 
 .PHONY: run-scylla
 run-scylla:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-  # 🚀 GocqlX [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/scylladb/gocqlx) [![Go Report Card](https://goreportcard.com/badge/github.com/scylladb/gocqlx)](https://goreportcard.com/report/github.com/scylladb/gocqlx) [![Build Status](https://travis-ci.org/scylladb/gocqlx.svg?branch=master)](https://travis-ci.org/scylladb/gocqlx)
+# 🚀 GocqlX [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/scylladb/gocqlx) [![Go Report Card](https://goreportcard.com/badge/github.com/scylladb/gocqlx)](https://goreportcard.com/report/github.com/scylladb/gocqlx) [![Build Status](https://travis-ci.org/scylladb/gocqlx.svg?branch=master)](https://travis-ci.org/scylladb/gocqlx)
 
 GocqlX makes working with Scylla easy and less error-prone.
 It’s inspired by [Sqlx](https://github.com/jmoiron/sqlx), a tool for working with SQL databases, but it goes beyond what Sqlx provides.

--- a/example_test.go
+++ b/example_test.go
@@ -631,6 +631,7 @@ func lwtLock(t *testing.T, session gocqlx.Session) {
 			If(qb.Eq("owner")).
 			TTLNamed("ttl").
 			Query(session).
+			SerialConsistency(gocql.Serial).
 			BindStruct(lock)
 
 		applied, err := q.ExecCASRelease()
@@ -652,6 +653,7 @@ func lwtLock(t *testing.T, session gocqlx.Session) {
 			TTLNamed("ttl").
 			Unique().
 			Query(session).
+			SerialConsistency(gocql.Serial).
 			BindStruct(lock)
 
 		applied, err = q.GetCASRelease(&prev)

--- a/migrate/README.md
+++ b/migrate/README.md
@@ -2,15 +2,13 @@
 
 Package `migrate` provides simple and flexible CQL migrations. 
 Migrations can be read from a flat directory containing cql files.
-There is no imposed naming schema, migration name is file name and the
-migrations are processed in lexicographical order. Caller provides a
-`gocql.Session`, the session must use a desired keyspace as migrate would try
-to create migrations table.
+There is no imposed naming schema, migration name is file name and the migrations are processed in lexicographical order.
+Caller provides a `gocqlx.Session`, the session must use a desired keyspace as migrate would try to create migrations table.
 
 ## Features
 
 * Each CQL statement will run once
-* Go code migrations using callbacks 
+* Go code migrations using callbacks
 
 ## Example
 
@@ -20,7 +18,7 @@ package main
 import (
     "context"
 
-    "github.com/scylladb/gocqlx/migrate"
+    "github.com/scylladb/gocqlx/v2/migrate"
 )
 
 const dir = "./cql" 

--- a/migrate/README.md
+++ b/migrate/README.md
@@ -1,35 +1,8 @@
-# GoCQLX Migrations
+# 🚀 GocqlX Migrations
 
-Package `migrate` provides simple and flexible CQL migrations. 
-Migrations can be read from a flat directory containing cql files.
-There is no imposed naming schema, migration name is file name and the migrations are processed in lexicographical order.
-Caller provides a `gocqlx.Session`, the session must use a desired keyspace as migrate would try to create migrations table.
+`migrate` reads migrations from a flat directory containing CQL files.
+There is no imposed naming schema. Migration name is file name.
+The order of migrations is the lexicographical order of file names in the directory. 
+You can inject execution of Go code before processing of a migration file, after processing of a migration file, or between statements in a migration file.
 
-## Features
-
-* Each CQL statement will run once
-* Go code migrations using callbacks
-
-## Example
-
-```go
-package main
-
-import (
-    "context"
-
-    "github.com/scylladb/gocqlx/v2/migrate"
-)
-
-const dir = "./cql" 
-
-func main() {
-    session := CreateSession()
-    defer session.Close()
-
-    ctx := context.Background()
-    if err := migrate.Migrate(ctx, session, dir); err != nil {
-        panic(err)
-    }
-}
-```
+For details see [example](example) migration.

--- a/migrate/callback.go
+++ b/migrate/callback.go
@@ -17,12 +17,17 @@ type CallbackEvent uint8
 const (
 	BeforeMigration CallbackEvent = iota
 	AfterMigration
+	CallComment
 )
 
-// CallbackFunc enables interrupting the migration process and executing code
-// while migrating. If error is returned the migration is aborted.
+// CallbackFunc enables execution of arbitrary Go code during migration.
+// If error is returned the migration is aborted.
+// BeforeMigration and AfterMigration are triggered before and after processing
+// of each migration file respectively.
+// CallComment is triggered for each comment in a form `-- CALL <name>;` (note the semicolon).
 type CallbackFunc func(ctx context.Context, session gocqlx.Session, ev CallbackEvent, name string) error
 
-// Callback is called before and after each migration.
+// Callback is means of executing Go code during migrations.
+// Use this variable to register a global callback dispatching function.
 // See CallbackFunc for details.
 var Callback CallbackFunc

--- a/migrate/doc.go
+++ b/migrate/doc.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a ALv2-style
 // license that can be found in the LICENSE file.
 
-// Package migrate provides simple and flexible CLQ migrations.
-// Migrations can be read from a flat directory containing cql files.
-// There is no imposed naming schema, migration name is file name and the migrations are processed in lexicographical order.
-// Caller provides a gocqlx.Session, the session must use a desired keyspace as migrate would try to create migrations table.
+// Package migrate reads migrations from a flat directory containing CQL files.
+// There is no imposed naming schema. Migration name is file name.
+// The order of migrations is the lexicographical order of file names in the directory.
+// You can inject execution of Go code before processing of a migration file, after processing of a migration file, or between statements in a migration file.
 package migrate

--- a/migrate/doc.go
+++ b/migrate/doc.go
@@ -4,8 +4,6 @@
 
 // Package migrate provides simple and flexible CLQ migrations.
 // Migrations can be read from a flat directory containing cql files.
-// There is no imposed naming schema, migration name is file name and the
-// migrations are processed in lexicographical order. Caller provides a
-// gocql.Session, the session must use a desired keyspace as migrate would try
-// to create migrations table.
+// There is no imposed naming schema, migration name is file name and the migrations are processed in lexicographical order.
+// Caller provides a gocqlx.Session, the session must use a desired keyspace as migrate would try to create migrations table.
 package migrate

--- a/migrate/example/example_test.go
+++ b/migrate/example/example_test.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2017 ScyllaDB
+// Use of this source code is governed by a ALv2-style
+// license that can be found in the LICENSE file.
+
+// +build all integration
+
+package example
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scylladb/gocqlx/v2"
+	"github.com/scylladb/gocqlx/v2/gocqlxtest"
+	"github.com/scylladb/gocqlx/v2/migrate"
+)
+
+// Running examples locally:
+// make run-scylla
+// make run-examples
+func TestExample(t *testing.T) {
+	const ks = "migrate_example"
+
+	cluster := gocqlxtest.CreateCluster()
+	cluster.Keyspace = ks
+
+	if err := gocqlxtest.CreateKeyspace(cluster, ks); err != nil {
+		t.Fatal("CreateKeyspace:", err)
+	}
+	session, err := gocqlx.WrapSession(cluster.CreateSession())
+	if err != nil {
+		t.Fatal("CreateSession:", err)
+	}
+	defer session.Close()
+
+	// Add callback prints
+	printEvent := func(ctx context.Context, session gocqlx.Session, ev migrate.CallbackEvent, name string) error {
+		t.Log(ev, name)
+		return nil
+	}
+
+	reg := migrate.CallbackRegister{}
+	reg.Add(migrate.BeforeMigration, "m1.cql", printEvent)
+	reg.Add(migrate.AfterMigration, "m1.cql", printEvent)
+	reg.Add(migrate.CallComment, "1", printEvent)
+	reg.Add(migrate.CallComment, "2", printEvent)
+	reg.Add(migrate.CallComment, "3", printEvent)
+
+	migrate.Callback = reg.Callback
+
+	// First run prints data
+	if err := migrate.Migrate(context.Background(), session, "migrations"); err != nil {
+		t.Fatal("Migrate:", err)
+	}
+
+	// Second run skips the processed files
+	if err := migrate.Migrate(context.Background(), session, "migrations"); err != nil {
+		t.Fatal("Migrate:", err)
+	}
+}

--- a/migrate/example/migrations/m1.cql
+++ b/migrate/example/migrations/m1.cql
@@ -1,0 +1,15 @@
+-- Comment
+
+CREATE TABLE bar ( id int PRIMARY KEY);
+
+INSERT INTO bar (id) VALUES (1);
+
+-- CALL 1;
+
+INSERT INTO bar (id) VALUES (2);
+
+-- CALL 2;
+
+INSERT INTO bar (id) VALUES (3);
+
+-- CALL 3;

--- a/migrate/export_test.go
+++ b/migrate/export_test.go
@@ -1,0 +1,5 @@
+package migrate
+
+func IsCallback(stmt string) (name string) {
+	return isCallback(stmt)
+}


### PR DESCRIPTION
This patch adds a new migration event type InMigration that it triggered by adding `-- DO <name>;` comment in a CQL file.

Fixes #101