### PR TITLE
Make qb.DESC of type qb.Order, not bool

### DIFF
--- a/qb/select.go
+++ b/qb/select.go
@@ -22,7 +22,7 @@ const (
 	// ASC is ascending order
 	ASC Order = true
 	// DESC is descending order
-	DESC = false
+	DESC Order = false
 )
 
 func (o Order) String() string {


### PR DESCRIPTION
Accidentally discovered by code along the lines of:
https://play.golang.com/p/b_tcqJjkleI

Language spec says the const-declaration expression part repeats, but the type does not (there is even an example).