### PR TITLE
Add <Cmp>TupleNamed for two-sided range-queries on tuples

### DIFF
--- a/qb/cmp.go
+++ b/qb/cmp.go
@@ -90,6 +90,18 @@ func EqNamed(column, name string) Cmp {
 	}
 }
 
+// EqTupleNamed produces column=(?,?,...) with count number of placeholders and custom name.
+func EqTupleNamed(column string, count int, name string) Cmp {
+	return Cmp{
+		op:     eq,
+		column: column,
+		value: tupleParam{
+			param: param(name),
+			count: count,
+		},
+	}
+}
+
 // EqLit produces column=literal and does not add a parameter to the query.
 func EqLit(column, literal string) Cmp {
 	return Cmp{
@@ -135,6 +147,18 @@ func NeNamed(column, name string) Cmp {
 		op:     ne,
 		column: column,
 		value:  param(name),
+	}
+}
+
+// NeTupleNamed produces column!=(?,?,...) with count number of placeholders and custom name.
+func NeTupleNamed(column string, count int, name string) Cmp {
+	return Cmp{
+		op:     ne,
+		column: column,
+		value: tupleParam{
+			param: param(name),
+			count: count,
+		},
 	}
 }
 
@@ -186,6 +210,18 @@ func LtNamed(column, name string) Cmp {
 	}
 }
 
+// LtTupleNamed produces column<(?,?,...) with count placeholders and custom name.
+func LtTupleNamed(column string, count int, name string) Cmp {
+	return Cmp{
+		op:     lt,
+		column: column,
+		value: tupleParam{
+			param: param(name),
+			count: count,
+		},
+	}
+}
+
 // LtLit produces column<literal and does not add a parameter to the query.
 func LtLit(column, literal string) Cmp {
 	return Cmp{
@@ -231,6 +267,18 @@ func LtOrEqNamed(column, name string) Cmp {
 		op:     leq,
 		column: column,
 		value:  param(name),
+	}
+}
+
+// LtOrEqTupleNamed produces column<=(?,?,...) with count placeholders and custom name.
+func LtOrEqTupleNamed(column string, count int, name string) Cmp {
+	return Cmp{
+		op:     leq,
+		column: column,
+		value: tupleParam{
+			param: param(name),
+			count: count,
+		},
 	}
 }
 
@@ -282,6 +330,18 @@ func GtNamed(column, name string) Cmp {
 	}
 }
 
+// GtTupleNamed produces column>(?,?,...) with count placeholders and custom name.
+func GtTupleNamed(column string, count int, name string) Cmp {
+	return Cmp{
+		op:     gt,
+		column: column,
+		value: tupleParam{
+			param: param(name),
+			count: count,
+		},
+	}
+}
+
 // GtLit produces column>literal and does not add a parameter to the query.
 func GtLit(column, literal string) Cmp {
 	return Cmp{
@@ -330,6 +390,18 @@ func GtOrEqNamed(column, name string) Cmp {
 	}
 }
 
+// GtOrEqTupleNamed produces column>=(?,?,...) with count placeholders and custom name.
+func GtOrEqTupleNamed(column string, count int, name string) Cmp {
+	return Cmp{
+		op:     geq,
+		column: column,
+		value: tupleParam{
+			param: param(name),
+			count: count,
+		},
+	}
+}
+
 // GtOrEqLit produces column>=literal and does not add a parameter to the query.
 func GtOrEqLit(column, literal string) Cmp {
 	return Cmp{
@@ -375,6 +447,18 @@ func InNamed(column, name string) Cmp {
 		op:     in,
 		column: column,
 		value:  param(name),
+	}
+}
+
+// InTupleNamed produces column IN ? with a custom parameter name.
+func InTupleNamed(column string, count int, name string) Cmp {
+	return Cmp{
+		op:     in,
+		column: column,
+		value: tupleParam{
+			param: param(name),
+			count: count,
+		},
 	}
 }
 
@@ -447,6 +531,30 @@ func ContainsKeyNamed(column, name string) Cmp {
 	}
 }
 
+// ContainsTupleNamed produces column CONTAINS (?,?,...) with count placeholders and custom name.
+func ContainsTupleNamed(column string, count int, name string) Cmp {
+	return Cmp{
+		op:     cnt,
+		column: column,
+		value: tupleParam{
+			param: param(name),
+			count: count,
+		},
+	}
+}
+
+// ContainsKeyTupleNamed produces column CONTAINS KEY (?,?,...) with count placehplders and custom name.
+func ContainsKeyTupleNamed(column string, count int, name string) Cmp {
+	return Cmp{
+		op:     cntKey,
+		column: column,
+		value: tupleParam{
+			param: param(name),
+			count: count,
+		},
+	}
+}
+
 // ContainsLit produces column CONTAINS literal and does not add a parameter to the query.
 func ContainsLit(column, literal string) Cmp {
 	return Cmp{
@@ -472,6 +580,18 @@ func LikeTuple(column string, count int) Cmp {
 		column: column,
 		value: tupleParam{
 			param: param(column),
+			count: count,
+		},
+	}
+}
+
+// LikeTupleNamed produces column LIKE (?,?,...) with count placeholders and custom name.
+func LikeTupleNamed(column string, count int, name string) Cmp {
+	return Cmp{
+		op:     like,
+		column: column,
+		value: tupleParam{
+			param: param(name),
 			count: count,
 		},
 	}

--- a/qb/cmp_test.go
+++ b/qb/cmp_test.go
@@ -160,6 +160,59 @@ func TestCmp(t *testing.T) {
 			S: "cntKey CONTAINS KEY ?",
 			N: []string{"name"},
 		},
+		{
+			C: LikeTupleNamed("like", 2, "name"),
+			S: "like LIKE (?,?)",
+			N: []string{"name_0", "name_1"},
+		},
+
+
+		// Custom bind names on tuples
+		{
+			C: EqTupleNamed("eq", 2, "name"),
+			S: "eq=(?,?)",
+			N: []string{"name_0", "name_1"},
+		},
+		{
+			C: NeTupleNamed("ne", 3, "name"),
+			S: "ne!=(?,?,?)",
+			N: []string{"name_0", "name_1", "name_2"},
+		},
+		{
+			C: LtTupleNamed("lt", 2, "name"),
+			S: "lt<(?,?)",
+			N: []string{"name_0", "name_1"},
+		},
+		{
+			C: LtOrEqTupleNamed("lt", 2, "name"),
+			S: "lt<=(?,?)",
+			N: []string{"name_0", "name_1"},
+		},
+		{
+			C: GtTupleNamed("gt", 2, "name"),
+			S: "gt>(?,?)",
+			N: []string{"name_0", "name_1"},
+		},
+		{
+			C: GtOrEqTupleNamed("gt", 2, "name"),
+			S: "gt>=(?,?)",
+			N: []string{"name_0", "name_1"},
+		},
+		{
+			C: InTupleNamed("in", 2, "name"),
+			S: "in IN (?,?)",
+			N: []string{"name_0", "name_1"},
+		},
+		{
+			C: ContainsTupleNamed("cnt", 2, "name"),
+			S: "cnt CONTAINS (?,?)",
+			N: []string{"name_0", "name_1"},
+		},
+		{
+			C: ContainsKeyTupleNamed("cntKey", 2, "name"),
+			S: "cntKey CONTAINS KEY (?,?)",
+			N: []string{"name_0", "name_1"},
+		},
 
 		// Literals
 		{

--- a/qb/cmp_test.go
+++ b/qb/cmp_test.go
@@ -31,7 +31,7 @@ func TestCmp(t *testing.T) {
 		{
 			C: NeTuple("ne", 3),
 			S: "ne!=(?,?,?)",
-			N: []string{"ne_0", "ne_1", "ne_2"},
+			N: []string{"ne[0]", "ne[1]", "ne[2]"},
 		},
 		{
 			C: Lt("lt"),
@@ -41,7 +41,7 @@ func TestCmp(t *testing.T) {
 		{
 			C: LtTuple("lt", 2),
 			S: "lt<(?,?)",
-			N: []string{"lt_0", "lt_1"},
+			N: []string{"lt[0]", "lt[1]"},
 		},
 		{
 			C: LtOrEq("lt"),
@@ -51,7 +51,7 @@ func TestCmp(t *testing.T) {
 		{
 			C: LtOrEqTuple("lt", 2),
 			S: "lt<=(?,?)",
-			N: []string{"lt_0", "lt_1"},
+			N: []string{"lt[0]", "lt[1]"},
 		},
 		{
 			C: Gt("gt"),
@@ -61,7 +61,7 @@ func TestCmp(t *testing.T) {
 		{
 			C: GtTuple("gt", 2),
 			S: "gt>(?,?)",
-			N: []string{"gt_0", "gt_1"},
+			N: []string{"gt[0]", "gt[1]"},
 		},
 		{
 			C: GtOrEq("gt"),
@@ -71,7 +71,7 @@ func TestCmp(t *testing.T) {
 		{
 			C: GtOrEqTuple("gt", 2),
 			S: "gt>=(?,?)",
-			N: []string{"gt_0", "gt_1"},
+			N: []string{"gt[0]", "gt[1]"},
 		},
 		{
 			C: In("in"),
@@ -81,7 +81,7 @@ func TestCmp(t *testing.T) {
 		{
 			C: InTuple("in", 2),
 			S: "in IN (?,?)",
-			N: []string{"in_0", "in_1"},
+			N: []string{"in[0]", "in[1]"},
 		},
 		{
 			C: Contains("cnt"),
@@ -91,7 +91,7 @@ func TestCmp(t *testing.T) {
 		{
 			C: ContainsTuple("cnt", 2),
 			S: "cnt CONTAINS (?,?)",
-			N: []string{"cnt_0", "cnt_1"},
+			N: []string{"cnt[0]", "cnt[1]"},
 		},
 		{
 			C: ContainsKey("cntKey"),
@@ -101,7 +101,7 @@ func TestCmp(t *testing.T) {
 		{
 			C: ContainsKeyTuple("cntKey", 2),
 			S: "cntKey CONTAINS KEY (?,?)",
-			N: []string{"cntKey_0", "cntKey_1"},
+			N: []string{"cntKey[0]", "cntKey[1]"},
 		},
 		{
 			C: Like("like"),
@@ -111,7 +111,7 @@ func TestCmp(t *testing.T) {
 		{
 			C: LikeTuple("like", 2),
 			S: "like LIKE (?,?)",
-			N: []string{"like_0", "like_1"},
+			N: []string{"like[0]", "like[1]"},
 		},
 
 		// Custom bind names
@@ -163,7 +163,7 @@ func TestCmp(t *testing.T) {
 		{
 			C: LikeTupleNamed("like", 2, "name"),
 			S: "like LIKE (?,?)",
-			N: []string{"name_0", "name_1"},
+			N: []string{"name[0]", "name[1]"},
 		},
 
 
@@ -171,47 +171,47 @@ func TestCmp(t *testing.T) {
 		{
 			C: EqTupleNamed("eq", 2, "name"),
 			S: "eq=(?,?)",
-			N: []string{"name_0", "name_1"},
+			N: []string{"name[0]", "name[1]"},
 		},
 		{
 			C: NeTupleNamed("ne", 3, "name"),
 			S: "ne!=(?,?,?)",
-			N: []string{"name_0", "name_1", "name_2"},
+			N: []string{"name[0]", "name[1]", "name[2]"},
 		},
 		{
 			C: LtTupleNamed("lt", 2, "name"),
 			S: "lt<(?,?)",
-			N: []string{"name_0", "name_1"},
+			N: []string{"name[0]", "name[1]"},
 		},
 		{
 			C: LtOrEqTupleNamed("lt", 2, "name"),
 			S: "lt<=(?,?)",
-			N: []string{"name_0", "name_1"},
+			N: []string{"name[0]", "name[1]"},
 		},
 		{
 			C: GtTupleNamed("gt", 2, "name"),
 			S: "gt>(?,?)",
-			N: []string{"name_0", "name_1"},
+			N: []string{"name[0]", "name[1]"},
 		},
 		{
 			C: GtOrEqTupleNamed("gt", 2, "name"),
 			S: "gt>=(?,?)",
-			N: []string{"name_0", "name_1"},
+			N: []string{"name[0]", "name[1]"},
 		},
 		{
 			C: InTupleNamed("in", 2, "name"),
 			S: "in IN (?,?)",
-			N: []string{"name_0", "name_1"},
+			N: []string{"name[0]", "name[1]"},
 		},
 		{
 			C: ContainsTupleNamed("cnt", 2, "name"),
 			S: "cnt CONTAINS (?,?)",
-			N: []string{"name_0", "name_1"},
+			N: []string{"name[0]", "name[1]"},
 		},
 		{
 			C: ContainsKeyTupleNamed("cntKey", 2, "name"),
 			S: "cntKey CONTAINS KEY (?,?)",
-			N: []string{"name_0", "name_1"},
+			N: []string{"name[0]", "name[1]"},
 		},
 
 		// Literals

--- a/qb/delete_test.go
+++ b/qb/delete_test.go
@@ -47,19 +47,19 @@ func TestDeleteBuilder(t *testing.T) {
 		{
 			B: Delete("cycling.cyclist_name").Where(EqTuple("id", 2)).Columns("stars"),
 			S: "DELETE stars FROM cycling.cyclist_name WHERE id=(?,?) ",
-			N: []string{"id_0", "id_1"},
+			N: []string{"id[0]", "id[1]"},
 		},
 		// Add WHERE for tuple column
 		{
 			B: Delete("cycling.cyclist_name").Where(w, GtTuple("firstname", 2)),
 			S: "DELETE FROM cycling.cyclist_name WHERE id=? AND firstname>(?,?) ",
-			N: []string{"expr", "firstname_0", "firstname_1"},
+			N: []string{"expr", "firstname[0]", "firstname[1]"},
 		},
 		// Add WHERE for all tuple columns
 		{
 			B: Delete("cycling.cyclist_name").Where(EqTuple("id", 2), GtTuple("firstname", 2)),
 			S: "DELETE FROM cycling.cyclist_name WHERE id=(?,?) AND firstname>(?,?) ",
-			N: []string{"id_0", "id_1", "firstname_0", "firstname_1"},
+			N: []string{"id[0]", "id[1]", "firstname[0]", "firstname[1]"},
 		},
 		// Add IF
 		{

--- a/qb/insert_test.go
+++ b/qb/insert_test.go
@@ -113,12 +113,12 @@ func TestInsertBuilder(t *testing.T) {
 		{
 			B: Insert("cycling.cyclist_name").TupleColumn("id", 2),
 			S: "INSERT INTO cycling.cyclist_name (id) VALUES ((?,?)) ",
-			N: []string{"id_0", "id_1"},
+			N: []string{"id[0]", "id[1]"},
 		},
 		{
 			B: Insert("cycling.cyclist_name").TupleColumn("id", 2).Columns("user_uuid"),
 			S: "INSERT INTO cycling.cyclist_name (id,user_uuid) VALUES ((?,?),?) ",
-			N: []string{"id_0", "id_1", "user_uuid"},
+			N: []string{"id[0]", "id[1]", "user_uuid"},
 		},
 		// Add IF NOT EXISTS
 		{

--- a/qb/select_test.go
+++ b/qb/select_test.go
@@ -70,13 +70,13 @@ func TestSelectBuilder(t *testing.T) {
 		{
 			B: Select("cycling.cyclist_name").Where(EqTuple("id", 2), Gt("firstname")),
 			S: "SELECT * FROM cycling.cyclist_name WHERE id=(?,?) AND firstname>? ",
-			N: []string{"id_0", "id_1", "firstname"},
+			N: []string{"id[0]", "id[1]", "firstname"},
 		},
 		// Add WHERE with only tuples
 		{
 			B: Select("cycling.cyclist_name").Where(EqTuple("id", 2), GtTuple("firstname", 2)),
 			S: "SELECT * FROM cycling.cyclist_name WHERE id=(?,?) AND firstname>(?,?) ",
-			N: []string{"id_0", "id_1", "firstname_0", "firstname_1"},
+			N: []string{"id[0]", "id[1]", "firstname[0]", "firstname[1]"},
 		},
 		// Add TIMEOUT
 		{

--- a/qb/update_test.go
+++ b/qb/update_test.go
@@ -48,7 +48,7 @@ func TestUpdateBuilder(t *testing.T) {
 		{
 			B: Update("cycling.cyclist_name").SetTuple("id", 2).Set("user_uuid", "firstname").Where(EqTuple("id", 2)),
 			S: "UPDATE cycling.cyclist_name SET id=(?,?),user_uuid=?,firstname=? WHERE id=(?,?) ",
-			N: []string{"id_0", "id_1", "user_uuid", "firstname", "id_0", "id_1"},
+			N: []string{"id[0]", "id[1]", "user_uuid", "firstname", "id[0]", "id[1]"},
 		},
 		// Add SET SetFunc
 		{

--- a/qb/value.go
+++ b/qb/value.go
@@ -32,16 +32,16 @@ type tupleParam struct {
 }
 
 func (t tupleParam) writeCql(cql *bytes.Buffer) (names []string) {
-	baseName := string(t.param) + "_"
+	baseName := string(t.param)
 	cql.WriteByte('(')
 	for i := 0; i < t.count-1; i++ {
 		cql.WriteByte('?')
 		cql.WriteByte(',')
-		names = append(names, baseName+strconv.Itoa(i))
+		names = append(names, baseName+"["+strconv.Itoa(i)+"]")
 	}
 	cql.WriteByte('?')
 	cql.WriteByte(')')
-	names = append(names, baseName+strconv.Itoa(t.count-1))
+	names = append(names, baseName+"["+strconv.Itoa(t.count-1)+"]")
 
 	return
 }


### PR DESCRIPTION
I found no other way to 
```
sometable.SelectBuilder(colSomeCol).
    Where(qb.GtOrEqTupleNamed(colCreatedAtID, 2, "start")).
    Where(qb.LtTupleNamed(colCreatedAtID, 2, "end")).
```
i.e. do specify a range scan on a tuple column with both ends of the range given. With only `qb.GtOrEqTuple` and `qb.LtTuple` the autogenerated names are both derived from the column name and collide, thus it is not possible to specify different ends for the range.

Before merging this, please also consider that tuple-element syntax has some conflict with `gocql`, which produces `"col[0]"` in `SliceMap`, and not `"col_0"` as gocqlx wants it during tuple binding.

Some options I see:
* Rename this PR's functions (or add yet more) with `<Cmp>TupleIdx` resp. `<Cmp>TupleIdxNamed` which autogenerate `gocql` compatible column names.
* Accept API breakage :( and change `tupleparam`. 
* Introduce `<Cmp>TupleNamedElements(column string, names ...string)` which gives names for all elements (thereby also specifying count)

If you tell me which of these two options you'd like to see, I'll be preparing an according follow-up PR.