### PR TITLE
Force metadata retrieval for CAS queries

### DIFF
--- a/queryx.go
+++ b/queryx.go
@@ -237,6 +237,7 @@ func (q *Queryx) ExecRelease() error {
 // ExecCAS executes the Lightweight Transaction query, returns whether query was applied.
 // See: https://docs.scylladb.com/using-scylla/lwt/ for more details.
 func (q *Queryx) ExecCAS() (applied bool, err error) {
+	q.NoSkipMetadata()
 	iter := q.Iter().StructOnly()
 	if err := iter.Get(&struct{}{}); err != nil {
 		return false, err
@@ -287,6 +288,7 @@ func (q *Queryx) GetCAS(dest interface{}) (applied bool, err error) {
 		return false, q.err
 	}
 
+	q.NoSkipMetadata()
 	iter := q.Iter()
 	if err := iter.Get(dest); err != nil {
 		return false, err


### PR DESCRIPTION
... otherwise the [applied] column is not noticed and setting of `Iterx.applied` is skipped. I'm not sure whether this is the right fix, to be honest; it seems a bit too ad-hoc.

Anyway, we noticed that after
```
applied, err := session.Query(table.InsertBuilder().Unique().ToCql()).BindStruct(data).ExecCASRelease()
```
`applied` would always be `false`, even if the LWT was in fact applied. Ultimately, this was due to no metadata being present in the iterator, thus Iterx.structScan not finding the `[applied]` column. The commit in this PR fixes that by forcing metadata retrieval for the two CAS methods, _but_ both from the timeline of the commits in `gocql` and `gocqlx` and from the testsuite of `gocqlx` this seems like it should actually work without this PR.

... which is due to the CI being run against scyllaDB (and not Cassandra)

Running against Cassandra 3.11.9 (came with Temporal.io):
```
sp ~/go/gocqlx % make test
[...]
--- FAIL: TestIterxCAS (1.72s)
    iterx_test.go:653: ExecCAS() expected first insert success
    iterx_test.go:676: GetCAS() expected update to be applied
    iterx_test.go:687: GetCAS() expected update to be applied
    iterx_test.go:690: GetCAS()=%=v expected to have pre-image {0 1000}
```

:point_up: current `master`
:point_down: with this PR
```
--- FAIL: TestIterxCAS (1.71s)
    iterx_test.go:690: GetCAS()=%=v expected to have pre-image {0 1000}
FAIL
```