### PR TITLE
fix using timeout order in select stmt

### DIFF
--- a/qb/select.go
+++ b/qb/select.go
@@ -84,7 +84,6 @@ func (b *SelectBuilder) ToCql() (stmt string, names []string) {
 	cql.WriteString(b.table)
 	cql.WriteByte(' ')
 
-	names = append(names, b.using.writeCql(&cql)...)
 	names = append(names, b.where.writeCql(&cql)...)
 
 	if len(b.groupBy) > 0 {
@@ -109,6 +108,8 @@ func (b *SelectBuilder) ToCql() (stmt string, names []string) {
 	if b.bypassCache {
 		cql.WriteString("BYPASS CACHE ")
 	}
+
+	names = append(names, b.using.writeCql(&cql)...)
 
 	stmt = cql.String()
 	return

--- a/qb/select_test.go
+++ b/qb/select_test.go
@@ -81,13 +81,13 @@ func TestSelectBuilder(t *testing.T) {
 		// Add TIMEOUT
 		{
 			B: Select("cycling.cyclist_name").Where(w, Gt("firstname")).Timeout(time.Second),
-			S: "SELECT * FROM cycling.cyclist_name USING TIMEOUT 1s WHERE id=? AND firstname>? ",
+			S: "SELECT * FROM cycling.cyclist_name WHERE id=? AND firstname>? USING TIMEOUT 1s ",
 			N: []string{"expr", "firstname"},
 		},
 		{
 			B: Select("cycling.cyclist_name").Where(w, Gt("firstname")).TimeoutNamed("to"),
-			S: "SELECT * FROM cycling.cyclist_name USING TIMEOUT ? WHERE id=? AND firstname>? ",
-			N: []string{"to", "expr", "firstname"},
+			S: "SELECT * FROM cycling.cyclist_name WHERE id=? AND firstname>? USING TIMEOUT ? ",
+			N: []string{"expr", "firstname", "to"},
 		},
 		// Add GROUP BY
 		{


### PR DESCRIPTION
Looking at the select statement specification [here](https://docs.scylladb.com/getting-started/dml/#select-statement),
it seems the USING clause should be at the end of the statement.
