### PR TITLE
gocqlxtest: get config from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,26 @@ make run-scylla
 make run-examples
 ```
 
+## Testing
+
+For the testing purpose you can use `gocqlxtest` package:
+```go
+session := gocqlxtest.CreateSession(t)
+```
+To configure test session connection you can use both command-line
+arguments and environment variables:
+
+| CLI flag      | Environment Variable | Type     | Description                                      | Default     |
+|---------------|:---------------------|:---------|:-------------------------------------------------|:------------|
+| cluster       | CLUSTER              | string   | Comma-separated list of host:port tuples         | 127.0.0.1   |
+| keyspace      | KEYSPACE             | string   | Keyspace name                                    | gocqlx_test |
+| proto         | PROTO                | int      | Protocol version                                 | 0           |
+| cql           | CQL                  | string   | CQL version                                      | 3.0.0       |
+| rf            | RF                   | int      | Replication factor for test keyspace             | 1           |
+| retries       | RETRIES              | int      | Number of times to retry queries                 | 5           |
+| compressor    | COMPRESSOR           | string   | Compressor to use                                |             |
+| gocql.timeout | GOCQL.TIMEOUT        | duration | Sets the connection `timeout` for all operations | 5s          |
+
 ## Performance
 
 GocqlX performance is comparable to the raw `gocql` driver.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/gocql/gocql v0.0.0-20211015133455-b225f9b53fa1
 	github.com/google/go-cmp v0.5.4
+	github.com/namsral/flag v1.7.4-pre
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/scylladb/go-reflectx v1.0.1
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a

--- a/go.sum
+++ b/go.sum
@@ -3,13 +3,8 @@ github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCS
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gocql/gocql v0.0.0-20200131111108-92af2e088537 h1:NaMut1fdw76YYX/TPinSAbai4DShF5tPort3bHpET6g=
-github.com/gocql/gocql v0.0.0-20200131111108-92af2e088537/go.mod h1:DL0ekTmBSTdlNF25Orwt/JMzqIq3EJ4MVa/J/uK64OY=
 github.com/gocql/gocql v0.0.0-20211015133455-b225f9b53fa1 h1:px9qUCy/RNJNsfCam4m2IxWGxNuimkrioEF0vrrbPsg=
 github.com/gocql/gocql v0.0.0-20211015133455-b225f9b53fa1/go.mod h1:3gM2c4D3AnkISwBxGnMMsS8Oy4y2lhbPRsH4xnJrHG8=
-github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
-github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -22,6 +17,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/namsral/flag v1.7.4-pre h1:b2ScHhoCUkbsq0d2C15Mv+VU8bl8hAXV8arnWiOHNZs=
+github.com/namsral/flag v1.7.4-pre/go.mod h1:OXldTctbM6SWH1K899kPZcf65KxJiD7MsceFUpB5yDo=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef h1:NKxTG6GVGbfMXc2mIk+KphcH6hagbVXhcFkbTgYleTI=
 github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef/go.mod h1:tcaRap0jS3eifrEEllL6ZMd9dg8IlDpi2S1oARrQ+NI=

--- a/gocqlxtest/gocqlxtest.go
+++ b/gocqlxtest/gocqlxtest.go
@@ -5,7 +5,6 @@
 package gocqlxtest
 
 import (
-	"flag"
 	"fmt"
 	"strings"
 	"sync"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gocql/gocql"
+	"github.com/namsral/flag"
 	"github.com/scylladb/gocqlx/v2"
 )
 


### PR DESCRIPTION
PR for the issue #247 
With the replacement builtin `flags` package to `github.com/namsral/flag` we could take config as from flags so from env variables