### PR TITLE
Fix GetQueryContext method comment

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -97,7 +97,7 @@ func (t *Table) GetQuery(session gocqlx.Session, columns ...string) *gocqlx.Quer
 	return session.Query(t.Get(columns...))
 }
 
-// GetQueryContext returns query wrapped with context which gets by partition key.
+// GetQueryContext returns query wrapped with context which gets by primary key.
 func (t *Table) GetQueryContext(ctx context.Context, session gocqlx.Session, columns ...string) *gocqlx.Queryx {
 	return t.GetQuery(session, columns...).WithContext(ctx)
 }


### PR DESCRIPTION
In https://github.com/scylladb/gocqlx/pull/190 I forgot to update the comment of `GetQueryContext` as well. This PR fixes this.