### PR TITLE
Add SSL support to schemagen

### DIFF
--- a/cmd/schemagen/schemagen.go
+++ b/cmd/schemagen/schemagen.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/gocql/gocql"
+
 	"github.com/scylladb/gocqlx/v2"
 	_ "github.com/scylladb/gocqlx/v2/table"
 )
@@ -26,6 +27,7 @@ var (
 	flagOutput   = cmd.String("output", "models", "the name of the folder to output to")
 	flagUser     = cmd.String("user", "", "user for password authentication")
 	flagPassword = cmd.String("password", "", "password for password authentication")
+	flagSslPath  = cmd.String("sslpath", "", "path to a directory containing SSL certificates")
 )
 
 var (
@@ -117,6 +119,13 @@ func createSession() (gocqlx.Session, error) {
 		cluster.Authenticator = gocql.PasswordAuthenticator{
 			Username: *flagUser,
 			Password: *flagPassword,
+		}
+
+	}
+	if *flagSslPath != "" {
+		cluster.SslOpts = &gocql.SslOptions{
+			CaPath:                 *flagSslPath,
+			EnableHostVerification: false,
 		}
 	}
 	return gocqlx.WrapSession(cluster.CreateSession())


### PR DESCRIPTION
This pull request adds SSL support to the schemagen command in order to generate table models for Cassandra/Scylla clusters that require SSL/TLS encryption. The motivation behind this change is to align with the SSL requirements of AWS Keyspaces.

### Changes Made

- Added the `flagSslPath` flag to allow users to specify the path to a directory containing SSL certificates.

- Modified the `createSession() `function to include SSL options in the cluster configuration if the `flagSslPath` flag is provided.

- Configured SSL options with the provided certificate path and disabled host verification to ensure compatibility with AWS Keyspaces SSL settings.

### Testing
I have manually tested this feature by generating table models for an AWS Keyspaces cluster with SSL enabled. The models were successfully generated without any errors.

### Related Issue(s)
N/A

Please review this pull request and consider merging it into the main branch.

Thank you.