### PR TITLE
Marshal missing UDT fields as null instead of failing

### DIFF
--- a/iterx.go
+++ b/iterx.go
@@ -13,7 +13,7 @@ import (
 	"github.com/scylladb/go-reflectx"
 )
 
-// DefaultUnsafe enables the behavior of forcing the iterator to ignore
+// DefaultUnsafe enables the behavior of forcing queries and iterators to ignore
 // missing fields for all queries. See Unsafe below for more information.
 var DefaultUnsafe bool
 

--- a/iterx_test.go
+++ b/iterx_test.go
@@ -484,12 +484,8 @@ func TestIterxUnsafe(t *testing.T) {
 	})
 
 	t.Run("select default unsafe", func(t *testing.T) {
-		gocqlx.DefaultUnsafe = true
-		defer func() {
-			gocqlx.DefaultUnsafe = false
-		}()
 		var v []UnsafeTable
-		err := session.Query(stmt, nil).Iter().Select(&v)
+		err := session.Query(stmt, nil).Unsafe().Iter().Select(&v)
 		if err != nil {
 			t.Fatal("Select() failed:", err)
 		}

--- a/queryx.go
+++ b/queryx.go
@@ -215,6 +215,13 @@ func (q *Queryx) Bind(v ...interface{}) *Queryx {
 	return q
 }
 
+// Scan executes the query, copies the columns of the first selected
+// row into the values pointed at by dest and discards the rest. If no rows
+// were selected, ErrNotFound is returned.
+func (q *Queryx) Scan(v ...interface{}) error {
+	return q.Query.Scan(udtWrapSlice(q.Mapper, q.unsafe, v)...)
+}
+
 // Err returns any binding errors.
 func (q *Queryx) Err() error {
 	return q.err

--- a/session.go
+++ b/session.go
@@ -51,6 +51,7 @@ func (s Session) ContextQuery(ctx context.Context, stmt string, names []string) 
 		Names:  names,
 		Mapper: s.Mapper,
 		tr:     DefaultBindTransformer,
+		unsafe: DefaultUnsafe,
 	}
 }
 
@@ -65,6 +66,7 @@ func (s Session) Query(stmt string, names []string) *Queryx {
 		Names:  names,
 		Mapper: s.Mapper,
 		tr:     DefaultBindTransformer,
+		unsafe: DefaultUnsafe,
 	}
 }
 

--- a/udt.go
+++ b/udt.go
@@ -39,11 +39,17 @@ func makeUDT(value reflect.Value, mapper *reflectx.Mapper, unsafe bool) udt {
 
 func (u udt) MarshalUDT(name string, info gocql.TypeInfo) ([]byte, error) {
 	value, ok := u.field[name]
-	if !ok {
-		return nil, fmt.Errorf("missing name %q in %s", name, u.value.Type())
+
+	var data []byte
+	var err error
+	if ok {
+		data, err = gocql.Marshal(info, value.Interface())
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return gocql.Marshal(info, value.Interface())
+	return data, err
 }
 
 func (u udt) UnmarshalUDT(name string, info gocql.TypeInfo, data []byte) error {


### PR DESCRIPTION
We can't return an error in case a field is added to the UDT, otherwise existing code would break by simply altering the UDT in the database. For extra fields at the end of the UDT put nulls to be in line with gocql, but also python-driver and java-driver.

In gocql it was fixed in https://github.com/scylladb/gocql/commit/d2ed1bb74f3118a83a352e9ce912be765001efa4

java-driver https://github.com/datastax/java-driver/blob/ef56d561d97adcae48e0e6e8807f334aedc0d783/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/UdtCodec.java#L86
python-driver: https://github.com/datastax/python-driver/blob/15d715f4e686032b02ce785eca1d176d2b25e32b/cassandra/cqltypes.py#L1036