### PR TITLE
Replace Unsafe with Strict mechanism

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -345,8 +345,8 @@ func basicReadScyllaVersion(t *testing.T, session gocqlx.Session) {
 }
 
 // This examples shows how to bind data from a map using "BindMap" function,
-// override field name mapping using the "db" tags, and use "Unsafe" function
-// to handle situations where driver returns more coluns that we are ready to
+// override field name mapping using the "db" tags, with the default mechanism of
+// handling situations where driver returns more coluns that we are ready to
 // consume.
 func datatypesBlob(t *testing.T, session gocqlx.Session) {
 	t.Helper()
@@ -384,9 +384,8 @@ func datatypesBlob(t *testing.T, session gocqlx.Session) {
 	}{}
 	q := qb.Select("examples.blobs").Where(qb.EqLit("k", "1")).Query(session)
 
-	// Unsafe is used here to override validation error that check if all
-	// requested columns are consumed `failed: missing destination name "k" in struct` error
-	if err := q.Iter().Unsafe().Get(row); err != nil {
+	// By default missing UDT fields are treated as null instead of failing
+	if err := q.Iter().Get(row); err != nil {
 		t.Fatal("Get() failed:", err)
 	}
 

--- a/session.go
+++ b/session.go
@@ -51,7 +51,7 @@ func (s Session) ContextQuery(ctx context.Context, stmt string, names []string) 
 		Names:  names,
 		Mapper: s.Mapper,
 		tr:     DefaultBindTransformer,
-		unsafe: DefaultUnsafe,
+		strict: DefaultStrict,
 	}
 }
 
@@ -66,7 +66,7 @@ func (s Session) Query(stmt string, names []string) *Queryx {
 		Names:  names,
 		Mapper: s.Mapper,
 		tr:     DefaultBindTransformer,
-		unsafe: DefaultUnsafe,
+		strict: DefaultStrict,
 	}
 }
 

--- a/udt.go
+++ b/udt.go
@@ -26,14 +26,14 @@ var (
 type udt struct {
 	field  map[string]reflect.Value
 	value  reflect.Value
-	unsafe bool
+	strict bool
 }
 
-func makeUDT(value reflect.Value, mapper *reflectx.Mapper, unsafe bool) udt {
+func makeUDT(value reflect.Value, mapper *reflectx.Mapper, strict bool) udt {
 	return udt{
 		value:  value,
 		field:  mapper.FieldMap(value),
-		unsafe: unsafe,
+		strict: strict,
 	}
 }
 
@@ -42,7 +42,7 @@ func (u udt) MarshalUDT(name string, info gocql.TypeInfo) ([]byte, error) {
 	if ok {
 		return gocql.Marshal(info, value.Interface())
 	}
-	if u.unsafe {
+	if !u.strict {
 		return nil, nil
 	}
 	return nil, fmt.Errorf("missing name %q in %s", name, u.value.Type())
@@ -53,25 +53,25 @@ func (u udt) UnmarshalUDT(name string, info gocql.TypeInfo, data []byte) error {
 	if ok {
 		return gocql.Unmarshal(info, data, value.Addr().Interface())
 	}
-	if u.unsafe {
+	if !u.strict {
 		return nil
 	}
 	return fmt.Errorf("missing name %q in %s", name, u.value.Type())
 }
 
 // udtWrapValue adds UDT wrapper if needed.
-func udtWrapValue(value reflect.Value, mapper *reflectx.Mapper, unsafe bool) interface{} {
+func udtWrapValue(value reflect.Value, mapper *reflectx.Mapper, strict bool) interface{} {
 	if value.Type().Implements(autoUDTInterface) {
-		return makeUDT(value, mapper, unsafe)
+		return makeUDT(value, mapper, strict)
 	}
 	return value.Interface()
 }
 
 // udtWrapSlice adds UDT wrapper if needed.
-func udtWrapSlice(mapper *reflectx.Mapper, unsafe bool, v []interface{}) []interface{} {
+func udtWrapSlice(mapper *reflectx.Mapper, strict bool, v []interface{}) []interface{} {
 	for i := range v {
 		if _, ok := v[i].(UDT); ok {
-			v[i] = makeUDT(reflect.ValueOf(v[i]), mapper, unsafe)
+			v[i] = makeUDT(reflect.ValueOf(v[i]), mapper, strict)
 		}
 	}
 	return v


### PR DESCRIPTION
Previously by default the presence of a missing field in a udt would result in an error reported. The Unsafe mechanism could be used to ignore these fields.

This PR changes the default behavior to ignoring missing fields and only reporting an error if Strict mode is used. This approach is in line with the gocql. 

This is a breaking change and the major release will be needed.

Refs: #269 