### PR TITLE
Switch to use scylla image instead of scylla version, to be able to target enterprise

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     env:
-      SCYLLA_VERSION: 6.0.0
+      SCYLLA_IMAGE: scylladb/scylla:6.0.0
       GOBIN: ./bin
     steps:
       - name: Git Checkout

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: check test
 
-ifndef SCYLLA_VERSION
-SCYLLA_VERSION := latest
+ifndef SCYLLA_IMAGE
+SCYLLA_IMAGE := scylladb/scylla:6.0.0
 endif
 
 ifndef SCYLLA_CPU
@@ -55,9 +55,9 @@ run-examples:
 
 .PHONY: run-scylla
 run-scylla:
-	@echo "==> Running test instance of Scylla $(SCYLLA_VERSION)"
-	@docker pull scylladb/scylla:$(SCYLLA_VERSION)
-	@docker run --name gocqlx-scylla -p 9042:9042 --cpuset-cpus=$(SCYLLA_CPU) --memory 1G --rm -d scylladb/scylla:$(SCYLLA_VERSION)
+	@echo "==> Running test instance of Scylla $(SCYLLA_IMAGE)"
+	@docker pull $(SCYLLA_IMAGE)
+	@docker run --name gocqlx-scylla -p 9042:9042 --cpuset-cpus=$(SCYLLA_CPU) --memory 1G --rm -d $(SCYLLA_IMAGE)
 	@until docker exec gocqlx-scylla cqlsh -e "DESCRIBE SCHEMA"; do sleep 2; done
 
 .PHONY: stop-scylla


### PR DESCRIPTION
Currently `Makefile` uses `SCYLLA_VERSION` to define docker image.
Switching to `SCYLLA_IMAGE` instead will help to target enterprise, nightly or custom image