### PR TITLE
Update migration error messages

### DIFF
--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -135,7 +135,7 @@ func FromFS(ctx context.Context, session gocqlx.Session, f fs.FS) error {
 			return fmt.Errorf("calculate checksum for %q: %s", fm[i], err)
 		}
 		if dbm[i].Checksum != c {
-			return fmt.Errorf("file %q was tempered with, expected md5 %s", fm[i], dbm[i].Checksum)
+			return fmt.Errorf("file %q was tampered with, expected md5 %s", fm[i], dbm[i].Checksum)
 		}
 	}
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -128,7 +128,7 @@ func FromFS(ctx context.Context, session gocqlx.Session, f fs.FS) error {
 
 	for i := 0; i < len(dbm); i++ {
 		if dbm[i].Name != fm[i] {
-			return fmt.Errorf("inconsistent migrations found, expected %q got %q at %d", fm[i], dbm[i].Name, i)
+			return fmt.Errorf("inconsistent migrations found, expected %q got %q at %d", dbm[i].Name, fm[i], i)
 		}
 		c, err := fileChecksum(f, fm[i])
 		if err != nil {

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -83,7 +83,7 @@ func TestMigration(t *testing.T) {
 		f := makeTestFS(4)
 		writeFile(f, 3, "SELECT * FROM bla;")
 
-		if err := migrate.FromFS(ctx, session, f); err == nil || !strings.Contains(err.Error(), "tempered") {
+		if err := migrate.FromFS(ctx, session, f); err == nil || !strings.Contains(err.Error(), "tampered") {
 			t.Fatal("expected error")
 		} else {
 			t.Log(err)


### PR DESCRIPTION
Fixed a couple of error messages for migrate.go

The inconsistent migration error incorrectly swaps the migration names

### Steps to reproduce
1. Create a migration file named `0.0.1-set-up-tables.cql`
2. Run the migrations via `gocqlx.Migrate`
3. Rename the migration file to `0.0.1-set-up-tables-RENAMED.cql`
4. Run the migrations again

```
stderr: panic: inconsistent migrations found, expected "0.0.1.set-up-tables-RENAMED.cql" got "0.0.1.set-up-tables.cql" at 1
```

should instead be

```
stderr: panic: inconsistent migrations found, expected "0.0.1.set-up-tables.cql" got "0.0.1.set-up-tables-RENAMED.cql" at 1
```