### PR TITLE
Add option to add ALLOW FILTERING to the update query

### DIFF
--- a/qb/update.go
+++ b/qb/update.go
@@ -37,6 +37,7 @@ type UpdateBuilder struct {
 	_if         _if
 	using       using
 	exists      bool
+	allowFiltering    bool
 }
 
 // Update returns a new UpdateBuilder with the given table name.
@@ -70,6 +71,10 @@ func (b *UpdateBuilder) ToCql() (stmt string, names []string) {
 
 	if b.exists {
 		cql.WriteString("IF EXISTS ")
+	}
+
+	if b.allowFiltering {
+		cql.WriteString("ALLOW FILTERING ")
 	}
 
 	stmt = cql.String()
@@ -194,6 +199,12 @@ func (b *UpdateBuilder) AddLit(column, literal string) *UpdateBuilder {
 // AddFunc adds SET column=column+someFunc(?...) clauses to the query.
 func (b *UpdateBuilder) AddFunc(column string, fn *Func) *UpdateBuilder {
 	return b.addValue(column, fn)
+}
+
+// AllowFiltering sets a ALLOW FILTERING clause on the query.
+func (b *UpdateBuilder) AllowFiltering() *UpdateBuilder {
+	b.allowFiltering = true
+	return b
 }
 
 func (b *UpdateBuilder) addValue(column string, value value) *UpdateBuilder {

--- a/qb/update_test.go
+++ b/qb/update_test.go
@@ -161,6 +161,12 @@ func TestUpdateBuilder(t *testing.T) {
 			S: "UPDATE cycling.cyclist_name SET timestamp=timestamp-now() ",
 			N: nil,
 		},
+		// Add ALLOW FILTERING
+		{
+			B: Update("cycling.cyclist_name").Set("id", "user_uuid", "firstname").Where(w).AllowFiltering(),
+			S: "UPDATE cycling.cyclist_name SET id=?,user_uuid=?,firstname=? WHERE id=? ALLOW FILTERING ",
+			N: []string{"id", "user_uuid", "firstname", "expr"},
+		},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
Previously it was only possible to use `AllowFiltering()` on the select query builder.

This PR adds the option to add `ALLOW FILTERING` to the update query.

Fixes: #288 