### PR TITLE
Update README.md schemagen installation and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Subpackages provide additional functionality:
 ## Installation
 
 ```bash
-    go get -u github.com/scylladb/gocqlx/v3
+git clone git@github.com:scylladb/gocqlx.git
+cd gocqlx/cmd/schemagen/
+go install .
 ```
 
 ## Getting started
@@ -117,7 +119,7 @@ go get -u "github.com/scylladb/gocqlx/v3/cmd/schemagen"
 
 Usage:
 ```bash
-$GOBIN/schemagen [flags]
+schemagen [flags]
 
 Flags:
   -cluster string
@@ -134,7 +136,7 @@ Example:
 
 Running the following command for `examples` keyspace: 
 ```bash
-$GOBIN/schemagen -cluster="127.0.0.1:9042" -keyspace="examples" -output="models" -pkgname="models"
+schemagen -cluster="127.0.0.1:9042" -keyspace="examples" -output="models" -pkgname="models"
 ```
 
 Generates `models/models.go` as follows:


### PR DESCRIPTION
Reincarnation of https://github.com/scylladb/gocqlx/pull/268

After `gocqlx` switched to `scylladb/gocql` driver due to the presence `replace` dirrective in `go.mod` user can't ue `go install` anymore.
