### PR TITLE
Enhance cluster configuration with reconnection policy and improve co…

### DIFF
--- a/gocqlxtest/gocqlxtest.go
+++ b/gocqlxtest/gocqlxtest.go
@@ -50,7 +50,12 @@ func CreateCluster() *gocql.ClusterConfig {
 	cluster.CQLVersion = *flagCQL
 	cluster.Timeout = *flagTimeout
 	cluster.Consistency = gocql.Quorum
+	//cluster.NumConns = 2 // might be useful for testing
 	cluster.MaxWaitSchemaAgreement = 2 * time.Minute // travis might be slow
+	cluster.ReconnectionPolicy = &gocql.ConstantReconnectionPolicy{
+		MaxRetries: 10,
+		Interval: 3 * time.Second,
+	}
 	if *flagRetry > 0 {
 		cluster.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: *flagRetry}
 	}

--- a/gocqlxtest/gocqlxtest.go
+++ b/gocqlxtest/gocqlxtest.go
@@ -50,7 +50,6 @@ func CreateCluster() *gocql.ClusterConfig {
 	cluster.CQLVersion = *flagCQL
 	cluster.Timeout = *flagTimeout
 	cluster.Consistency = gocql.Quorum
-	//cluster.NumConns = 2 // might be useful for testing
 	cluster.MaxWaitSchemaAgreement = 2 * time.Minute // travis might be slow
 	cluster.ReconnectionPolicy = &gocql.ConstantReconnectionPolicy{
 		MaxRetries: 10,

--- a/queryx_wrap.go
+++ b/queryx_wrap.go
@@ -86,6 +86,9 @@ func (q *Queryx) RoutingKey(routingKey []byte) *Queryx {
 // query, queries will be canceled and return once the context is
 // canceled.
 func (q *Queryx) WithContext(ctx context.Context) *Queryx {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	q.Query = q.Query.WithContext(ctx)
 	return q
 }


### PR DESCRIPTION
This pull request includes updates to improve the configuration and error handling in the `gocqlxtest` and `queryx_wrap` packages. The most important changes are the addition of a reconnection policy in the `CreateCluster` function and the handling of nil contexts in the `WithContext` method.

Improvements to cluster configuration:

* [`gocqlxtest/gocqlxtest.go`](diffhunk://#diff-f1e07c9ab4b35901f3194ab930c220a948a03828320be2cccfccd9afe83bea47R53-R58): Added a reconnection policy to the `CreateCluster` function to improve reliability during connection retries.

Error handling improvements:

* [`queryx_wrap.go`](diffhunk://#diff-5d5f79db7be74fe022c69112a825b39532ce7830002f78dfd2ac163030812813R89-R91): Modified the `WithContext` method to handle nil contexts by defaulting to `context.Background()`.