### PR TITLE
Enhance cluster configuration with reconnection policy and improve code

### DIFF
--- a/gocqlxtest/gocqlxtest.go
+++ b/gocqlxtest/gocqlxtest.go
@@ -51,6 +51,10 @@ func CreateCluster() *gocql.ClusterConfig {
 	cluster.Timeout = *flagTimeout
 	cluster.Consistency = gocql.Quorum
 	cluster.MaxWaitSchemaAgreement = 2 * time.Minute // travis might be slow
+	cluster.ReconnectionPolicy = &gocql.ConstantReconnectionPolicy{
+		MaxRetries: 10,
+		Interval:   3 * time.Second,
+	}
 	if *flagRetry > 0 {
 		cluster.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: *flagRetry}
 	}

--- a/queryx_wrap.go
+++ b/queryx_wrap.go
@@ -86,6 +86,9 @@ func (q *Queryx) RoutingKey(routingKey []byte) *Queryx {
 // query, queries will be canceled and return once the context is
 // canceled.
 func (q *Queryx) WithContext(ctx context.Context) *Queryx {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	q.Query = q.Query.WithContext(ctx)
 	return q
 }


### PR DESCRIPTION
This pull request includes changes to improve the resilience and robustness of the `gocqlx` library by adding reconnection policies and handling `nil` contexts. The most important changes include the addition of a constant reconnection policy in the `CreateCluster` function and the handling of `nil` contexts in the `WithContext` method.

Improvements to resilience and robustness:

* [`gocqlxtest/gocqlxtest.go`](diffhunk://#diff-f1e07c9ab4b35901f3194ab930c220a948a03828320be2cccfccd9afe83bea47R54-R57): Added a constant reconnection policy to handle reconnections with a maximum of 10 retries and a 3-second interval between retries in the `CreateCluster` function.
* [`queryx_wrap.go`](diffhunk://#diff-5d5f79db7be74fe022c69112a825b39532ce7830002f78dfd2ac163030812813R89-R91): Modified the `WithContext` method in the `Queryx` struct to handle `nil` contexts by defaulting to `context.Background()`.