### PR TITLE
Refactor Makefile tools installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SCYLLA_IMAGE: scylladb/scylla
-      GOBIN: ./bin
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -32,9 +31,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('go.mod') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
-      - name: Make Directory for GOBIN
-        run: mkdir -p "${GOBIN}"
 
       - name: Download Dependencies
         run: git --version && make get-deps && make get-tools

--- a/qb/update.go
+++ b/qb/update.go
@@ -31,13 +31,13 @@ func (a assignment) writeCql(cql *bytes.Buffer) (names []string) {
 
 // UpdateBuilder builds CQL UPDATE statements.
 type UpdateBuilder struct {
-	table       string
-	assignments []assignment
-	where       where
-	_if         _if
-	using       using
-	exists      bool
-	allowFiltering    bool
+	table          string
+	assignments    []assignment
+	where          where
+	_if            _if
+	using          using
+	exists         bool
+	allowFiltering bool
 }
 
 // Update returns a new UpdateBuilder with the given table name.


### PR DESCRIPTION
Updating tools is not easy due to the bad Makefile design
Make it easier to update tools, preparing to golang and gocql update.