### PR TITLE
Update golang to 1.20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,30 +7,39 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+env:
+  # On CICD following error shows up:
+  #   go: github.com/gocql/gocql@v1.7.0: GOPROXY list is not the empty string, but contains no entries
+  # This env variable is set to make it go away
+  # If at some point you see no error, feel free to remove it
+  GOPROXY: direct
+  # On CICD following error shows up:
+  #   go: golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@v0.24.0: golang.org/x/tools@v0.24.0: verifying module: missing GOSUMDB
+  # This env variable makes it go away
+  # If at some point you see no error, feel free to remove it
+  GOSUMDB: off
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      SCYLLA_IMAGE: scylladb/scylla
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: '0'
+
       - name: Install Go 1.20
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - name: Cache Dependencies
         uses: actions/cache@v4
         id: gomod-cache
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ hashFiles('go.mod', 'cmd/schemagen/testdata/go.mod') }}
 
       - name: Download Dependencies
         run: git --version && make get-deps && make get-tools

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-      - name: Install Go 1.17
+      - name: Install Go 1.20
         uses: actions/setup-go@v5
         with:
-          go-version: 1.17
+          go-version: 1.20
 
       - name: Cache Dependencies
         uses: actions/cache@v4

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GOOS := $(shell uname | tr '[:upper:]' '[:lower:]')
 GOARCH := $(shell go env GOARCH)
 
 GOLANGCI_VERSION := 1.64.8
-FIELDALIGNMENT_VERSION := 0.11.0
+FIELDALIGNMENT_VERSION := 0.24.0
 
 ifeq ($(GOARCH),arm64)
 	GOLANGCI_DOWNLOAD_URL := "https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_VERSION)/golangci-lint-$(GOLANGCI_VERSION)-$(GOOS)-arm64.tar.gz"

--- a/cmd/schemagen/schemagen_test.go
+++ b/cmd/schemagen/schemagen_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -32,17 +31,17 @@ func TestSchemagen(t *testing.T) {
 
 	const goldenFile = "testdata/models.go"
 	if *flagUpdate {
-		if err := ioutil.WriteFile(goldenFile, b, os.ModePerm); err != nil {
+		if err := os.WriteFile(goldenFile, b, os.ModePerm); err != nil {
 			t.Fatal(err)
 		}
 	}
-	golden, err := ioutil.ReadFile(goldenFile)
+	golden, err := os.ReadFile(goldenFile)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if diff := cmp.Diff(string(golden), string(b)); diff != "" {
-		t.Fatalf(diff)
+		t.Fatal(diff)
 	}
 }
 

--- a/cmd/schemagen/testdata/go.mod
+++ b/cmd/schemagen/testdata/go.mod
@@ -1,6 +1,6 @@
 module schemagentest
 
-go 1.17
+go 1.20
 
 require (
 	github.com/gocql/gocql v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scylladb/gocqlx/v3
 
-go 1.17
+go 1.20
 
 require (
 	github.com/gocql/gocql v1.7.0

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -208,7 +207,7 @@ func applyMigration(ctx context.Context, session gocqlx.Session, f fs.FS, path s
 		return err
 	}
 
-	b, err := ioutil.ReadAll(file)
+	b, err := io.ReadAll(file)
 	file.Close()
 	if err != nil {
 		return err


### PR DESCRIPTION
Does the following:
1. Update golang on both `go.mod` files to `1.20`
2. Updates workflow to make it work on golang `1.20`
3. Fixes problem with depricated `ioutils` pacakge.
