### PR TITLE
Add ContextBatch api to create batch with context

### DIFF
--- a/batchx.go
+++ b/batchx.go
@@ -1,8 +1,8 @@
 package gocqlx
 
 import (
+	"context"
 	"fmt"
-
 	"github.com/gocql/gocql"
 )
 
@@ -12,9 +12,25 @@ type Batch struct {
 }
 
 // NewBatch creates a new batch operation using defaults defined in the cluster.
+//
+// Deprecated: use session.Batch instead
 func (s *Session) NewBatch(bt gocql.BatchType) *Batch {
 	return &Batch{
-		Batch: s.Session.NewBatch(bt),
+		Batch: s.Session.Batch(bt),
+	}
+}
+
+// Batch creates a new batch operation using defaults defined in the cluster.
+func (s *Session) Batch(bt gocql.BatchType) *Batch {
+	return &Batch{
+		Batch: s.Session.Batch(bt),
+	}
+}
+
+// ContextBatch creates a new batch operation using defaults defined in the cluster with attached context.
+func (s *Session) ContextBatch(ctx context.Context, bt gocql.BatchType) *Batch {
+	return &Batch{
+		Batch: s.Session.Batch(bt).WithContext(ctx),
 	}
 }
 

--- a/qb/batch.go
+++ b/qb/batch.go
@@ -34,7 +34,7 @@ type BatchBuilder struct {
 //   - gocql.Batch prepares the included statements separately, which is more efficient.
 //     In contrast, gocqlx.qb.BatchBuilder, which is based on gocql.Query, prepares the whole batch statements as one ordinary query.
 //
-// Deprecated: Please use gocql.Session.NewBatch() instead.
+// Deprecated: please use gocql.Session.Batch() instead.
 func Batch() *BatchBuilder {
 	return &BatchBuilder{}
 }


### PR DESCRIPTION
Fixes: https://github.com/scylladb/gocqlx/issues/322

Adds missing `ContextBatch` and `Batch` API, marks `NewBatch` as depricated.