### PR TITLE
Bring back index model generation

### DIFF
--- a/cmd/schemagen/keyspace.tmpl
+++ b/cmd/schemagen/keyspace.tmpl
@@ -9,9 +9,9 @@ import (
 	{{- end}}
 )
 
+{{with .Tables}}
 // Table models.
 var (
-{{with .Tables}}
 {{range .}}
 	{{$model_name := .Name | camelize}}
 		{{$model_name}} = table.New(table.Metadata {
@@ -33,13 +33,13 @@ var (
 			},
 	})
 {{end}}
-{{end}}
 )
+{{end}}
 
+{{with .Views}}
 // Materialized view models.
 var (
-{{with .Views}}
-{{range .}}
+{{- range .}}
 	{{$model_name := .ViewName | camelize}}
 		{{$model_name}} = table.New(table.Metadata {
 			Name:	"{{.ViewName}}",
@@ -60,11 +60,39 @@ var (
 			},
 	})
 {{end}}
+)
+{{end}}
+
+{{with .Indexes}}
+// Index models.
+var (
+{{range .}}
+	{{$model_name := .Name | camelize}}
+		{{$model_name}}Index = table.New(table.Metadata {
+			Name:	"{{.Name}}_index",
+			Columns: []string{
+				{{- range .OrderedColumns}}
+					"{{.}}",
+				{{- end}}
+			},
+			PartKey: []string {
+				{{- range .PartitionKey}}
+					"{{.Name}}",
+				{{- end}}
+			},
+			SortKey: []string{
+				{{- range .ClusteringColumns}}
+					"{{.Name}}",
+				{{- end}}
+			},
+	})
 {{end}}
 )
+{{end}}
 
 {{with .UserTypes}}
-{{range .}}
+// User-defined types (UDT) structs.
+{{- range .}}
 {{- $type_name := .Name | camelize}}
 {{- $field_types := .FieldTypes}}
 type {{$type_name}}UserType struct {
@@ -77,7 +105,8 @@ type {{$type_name}}UserType struct {
 {{- end}}
 
 {{with .Tables}}
-{{range .}}
+// Table structs.
+{{- range .}}
 {{- $model_name := .Name | camelize}}
 type {{$model_name}}Struct struct {
 {{- range .Columns}}
@@ -90,9 +119,24 @@ type {{$model_name}}Struct struct {
 {{- end}}
 
 {{with .Views}}
-{{range .}}
+// View structs.
+{{- range .}}
 {{- $model_name := .ViewName | camelize}}
 type {{$model_name}}Struct struct {
+{{- range .Columns}}
+	{{- if not (eq .Type "empty") }}
+	{{.Name | camelize}} {{.Type | mapScyllaToGoType}}
+	{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- end}}
+
+{{with .Indexes}}
+// Index structs.
+{{- range .}}
+{{- $model_name := .Name | camelize}}
+type {{$model_name}}IndexStruct struct {
 {{- range .Columns}}
 	{{- if not (eq .Type "empty") }}
 	{{.Name | camelize}} {{.Type | mapScyllaToGoType}}

--- a/cmd/schemagen/testdata/no_ignore_indexes/models.go
+++ b/cmd/schemagen/testdata/no_ignore_indexes/models.go
@@ -47,6 +47,25 @@ var (
 	})
 )
 
+// Index models.
+var (
+	SongsTitleIndex = table.New(table.Metadata{
+		Name: "songs_title_index",
+		Columns: []string{
+			"id",
+			"idx_token",
+			"title",
+		},
+		PartKey: []string{
+			"title",
+		},
+		SortKey: []string{
+			"idx_token",
+			"id",
+		},
+	})
+)
+
 // User-defined types (UDT) structs.
 type AlbumUserType struct {
 	gocqlx.UDT
@@ -69,5 +88,12 @@ type SongsStruct struct {
 	Duration gocql.Duration
 	Id       [16]byte
 	Tags     []string
+	Title    string
+}
+
+// Index structs.
+type SongsTitleIndexStruct struct {
+	Id       [16]byte
+	IdxToken int64
 	Title    string
 }


### PR DESCRIPTION
Related to #320.

This PR is the final piece in restoring backward compatibility with `schemagen@v2`. It adds generation of index models with some tests specific to this case. Also, it fixes minor issues and makes generated source file a little bit prettier.