### PR TITLE
Bump required gocql version

### DIFF
--- a/cmd/schemagen/testdata/go.mod
+++ b/cmd/schemagen/testdata/go.mod
@@ -3,7 +3,7 @@ module schemagentest
 go 1.20
 
 require (
-	github.com/gocql/gocql v1.7.0
+	github.com/gocql/gocql v1.15.1
 	github.com/google/go-cmp v0.7.0
 	github.com/scylladb/gocqlx/v3 v3.0.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/scylladb/gocqlx/v3
 go 1.20
 
 require (
-	github.com/gocql/gocql v1.7.0
+	github.com/gocql/gocql v1.15.1
 	github.com/google/go-cmp v0.7.0
 	github.com/psanford/memfs v0.0.0-20241019191636-4ef911798f9b
 	github.com/scylladb/go-reflectx v1.0.1


### PR DESCRIPTION
`SetHostID` methods added in gocql v1.15.1 are needed for new API added in 3.0.2. 

Refs: #330 