### PR TITLE
Upgrade gocql to 1.15.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ However, starting with v3.0.0, GocqlX exclusively supports the scylladb/gocql dr
 If you are using GocqlX v3.0.0 or newer, you must ensure your `go.mod` includes a replace directive to point to ScyllaDB’s fork:
 
 ```go
-# Use the latest version of scylladb/gocql; check for updates at https://github.com/scylladb/gocql/releases
-replace github.com/gocql/gocql => github.com/scylladb/gocql v1.15.1
+// Use the latest version of scylladb/gocql; check for updates at https://github.com/scylladb/gocql/releases
+replace github.com/gocql/gocql => github.com/scylladb/gocql v1.15.3
 ```
 
 This is required because GocqlX relies on ScyllaDB-specific extensions and bug fixes introduced in the gocql fork. Attempting to use the standard gocql driver with GocqlX v3.0.0+ may lead to build or runtime issues.

--- a/batchx.go
+++ b/batchx.go
@@ -3,6 +3,8 @@ package gocqlx
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/gocql/gocql"
 )
 
@@ -32,6 +34,19 @@ func (s *Session) ContextBatch(ctx context.Context, bt gocql.BatchType) *Batch {
 	return &Batch{
 		Batch: s.Session.Batch(bt).WithContext(ctx),
 	}
+}
+
+// GetRequestTimeout returns time driver waits for single server response
+// This timeout is applied to preparing statement request and for query execution requests
+func (b *Batch) GetRequestTimeout() time.Duration {
+	return b.Batch.GetRequestTimeout()
+}
+
+// SetRequestTimeout sets time driver waits for server to respond
+// This timeout is applied to preparing statement request and for query execution requests
+func (b *Batch) SetRequestTimeout(timeout time.Duration) *Batch {
+	b.Batch.SetRequestTimeout(timeout)
+	return b
 }
 
 // SetHostID allows to define the host the query should be executed against. If the

--- a/cmd/schemagen/testdata/go.mod
+++ b/cmd/schemagen/testdata/go.mod
@@ -16,6 +16,6 @@ require (
 )
 
 replace (
-	github.com/gocql/gocql => github.com/scylladb/gocql v1.15.2
+	github.com/gocql/gocql => github.com/scylladb/gocql v1.15.3
 	github.com/scylladb/gocqlx/v3 => ../../..
 )

--- a/cmd/schemagen/testdata/go.sum
+++ b/cmd/schemagen/testdata/go.sum
@@ -22,6 +22,7 @@ github.com/scylladb/gocql v1.15.1 h1:t75NkDFys0XxipPsnTrSEbwx8B8R/jTUt5OAY9W7i+c
 github.com/scylladb/gocql v1.15.1/go.mod h1:+rInt+HjERaMEYC4N8LocQQEAdREhYKU4QPkE00K5dA=
 github.com/scylladb/gocql v1.15.2 h1:Vv7iaIyTMMjMtux1INQMi0waH8j8O/ppKS6JcM1vh14=
 github.com/scylladb/gocql v1.15.2/go.mod h1:+rInt+HjERaMEYC4N8LocQQEAdREhYKU4QPkE00K5dA=
+github.com/scylladb/gocql v1.15.3/go.mod h1:+rInt+HjERaMEYC4N8LocQQEAdREhYKU4QPkE00K5dA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/go.mod
+++ b/go.mod
@@ -16,4 +16,4 @@ require (
 	github.com/klauspost/compress v1.17.9 // indirect
 )
 
-replace github.com/gocql/gocql => github.com/scylladb/gocql v1.15.2
+replace github.com/gocql/gocql => github.com/scylladb/gocql v1.15.3

--- a/go.sum
+++ b/go.sum
@@ -21,10 +21,8 @@ github.com/psanford/memfs v0.0.0-20241019191636-4ef911798f9b h1:xzjEJAHum+mV5Dd5
 github.com/psanford/memfs v0.0.0-20241019191636-4ef911798f9b/go.mod h1:tcaRap0jS3eifrEEllL6ZMd9dg8IlDpi2S1oARrQ+NI=
 github.com/scylladb/go-reflectx v1.0.1 h1:b917wZM7189pZdlND9PbIJ6NQxfDPfBvUaQ7cjj1iZQ=
 github.com/scylladb/go-reflectx v1.0.1/go.mod h1:rWnOfDIRWBGN0miMLIcoPt/Dhi2doCMZqwMCJ3KupFc=
-github.com/scylladb/gocql v1.15.1 h1:t75NkDFys0XxipPsnTrSEbwx8B8R/jTUt5OAY9W7i+c=
-github.com/scylladb/gocql v1.15.1/go.mod h1:+rInt+HjERaMEYC4N8LocQQEAdREhYKU4QPkE00K5dA=
-github.com/scylladb/gocql v1.15.2 h1:Vv7iaIyTMMjMtux1INQMi0waH8j8O/ppKS6JcM1vh14=
-github.com/scylladb/gocql v1.15.2/go.mod h1:+rInt+HjERaMEYC4N8LocQQEAdREhYKU4QPkE00K5dA=
+github.com/scylladb/gocql v1.15.3 h1:0vJT5pm7g5v8/pCs3tuXuRAfSRWvc1kib8J846Z+Z4g=
+github.com/scylladb/gocql v1.15.3/go.mod h1:+rInt+HjERaMEYC4N8LocQQEAdREhYKU4QPkE00K5dA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/queryx.go
+++ b/queryx.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/gocql/gocql"
 	"github.com/scylladb/go-reflectx"
@@ -144,6 +145,19 @@ func (q *Queryx) BindStructMap(arg0 interface{}, arg1 map[string]interface{}) *Q
 		q.Bind(arglist...)
 	}
 
+	return q
+}
+
+// GetRequestTimeout returns time driver waits for single server response
+// This timeout is applied to preparing statement request and for query execution requests
+func (q *Queryx) GetRequestTimeout() time.Duration {
+	return q.Query.GetRequestTimeout()
+}
+
+// SetRequestTimeout sets time driver waits for server to respond
+// This timeout is applied to preparing statement request and for query execution requests
+func (q *Queryx) SetRequestTimeout(timeout time.Duration) *Queryx {
+	q.Query.SetRequestTimeout(timeout)
 	return q
 }
 


### PR DESCRIPTION
gocql 1.15.3 brings new APIs for `gocql.Batch` and `gocql.Query`:
- `SetRequestTimeout`
- `GetRequestTimeout`

So, this change adds relative APIs to the `gocqlx.Batch` and `gocqlx.Queryx`.