### PR TITLE
Fix: #340 Add comment handling and related tests for migration functionality

### DIFF
--- a/migrate/export_test.go
+++ b/migrate/export_test.go
@@ -3,3 +3,7 @@ package migrate
 func IsCallback(stmt string) (name string) {
 	return isCallback(stmt)
 }
+
+func IsComment(stmt string) bool {
+	return isComment(stmt)
+}


### PR DESCRIPTION
This pull request improves the migration system by introducing logic to correctly handle SQL comments in migration files, ensuring that regular comments (including trailing comments after statements) are ignored during migration execution. It also adds comprehensive tests to verify this behavior and documents the new logic for clarity.

**Migration logic improvements:**

* Added the `isComment` function to distinguish regular SQL comments from callback commands, ensuring only valid statements and callbacks are processed during migrations (`migrate/migrate.go`).
* Updated the migration execution flow so that regular comments and empty statements are silently skipped, preventing errors from trailing comments in migration files (`migrate/migrate.go`).

**Testing enhancements:**

* Added the `TestMigrationWithTrailingComment` test to verify that migrations with trailing comments succeed without error (`migrate/migrate_test.go`).
* Added the `TestIsComment` test suite to validate the behavior of the new `isComment` function for various statement types (`migrate/migrate_test.go`).
* Exposed the `IsComment` function for use in tests and other packages (`migrate/export_test.go`).

**Documentation updates:**

* Documented the new migration logic and statement handling in the comments for the `applyMigration` function, clarifying the distinction between SQL statements, callback commands, and regular comments (`migrate/migrate.go`).

**What fixed**
https://github.com/scylladb/gocqlx/issues/340