### PR TITLE
qb: add quoted string literal comparison

### DIFF
--- a/qb/cmp.go
+++ b/qb/cmp.go
@@ -103,11 +103,21 @@ func EqTupleNamed(column string, count int, name string) Cmp {
 }
 
 // EqLit produces column=literal and does not add a parameter to the query.
+// The literal is written verbatim; use EqLitString for string values.
 func EqLit(column, literal string) Cmp {
 	return Cmp{
 		op:     eq,
 		column: column,
 		value:  lit(literal),
+	}
+}
+
+// EqLitString produces column='literal' and escapes the string for CQL.
+func EqLitString(column, literal string) Cmp {
+	return Cmp{
+		op:     eq,
+		column: column,
+		value:  stringLit(literal),
 	}
 }
 

--- a/qb/cmp_test.go
+++ b/qb/cmp_test.go
@@ -218,6 +218,14 @@ func TestCmp(t *testing.T) {
 			S: "eq=litval",
 		},
 		{
+			C: EqLitString("eq", "RUNNING"),
+			S: "eq='RUNNING'",
+		},
+		{
+			C: EqLitString("eq", "O'Brien"),
+			S: "eq='O''Brien'",
+		},
+		{
 			C: NeLit("ne", "litval"),
 			S: "ne!=litval",
 		},

--- a/qb/update_test.go
+++ b/qb/update_test.go
@@ -104,6 +104,12 @@ func TestUpdateBuilder(t *testing.T) {
 			S: "UPDATE cycling.cyclist_name SET id=?,user_uuid=?,firstname=? WHERE id=? IF firstname>? ",
 			N: []string{"id", "user_uuid", "firstname", "expr", "firstname"},
 		},
+		// Add IF string literal
+		{
+			B: Update("scheduler_task_run").Set("status").Where(w).If(EqLitString("status", "RUNNING")),
+			S: "UPDATE scheduler_task_run SET status=? WHERE id=? IF status='RUNNING' ",
+			N: []string{"status", "expr"},
+		},
 		// Add TTL
 		{
 			B: Update("cycling.cyclist_name").Set("id", "user_uuid", "firstname").Where(w).TTL(time.Second),

--- a/qb/value.go
+++ b/qb/value.go
@@ -7,6 +7,7 @@ package qb
 import (
 	"bytes"
 	"strconv"
+	"strings"
 )
 
 // value is a CQL value expression for use in an initializer, assignment,
@@ -51,5 +52,15 @@ type lit string
 
 func (l lit) writeCql(cql *bytes.Buffer) (names []string) {
 	cql.WriteString(string(l))
+	return nil
+}
+
+// stringLit is a quoted CQL string literal.
+type stringLit string
+
+func (l stringLit) writeCql(cql *bytes.Buffer) (names []string) {
+	cql.WriteByte('\'')
+	cql.WriteString(strings.ReplaceAll(string(l), "'", "''"))
+	cql.WriteByte('\'')
 	return nil
 }


### PR DESCRIPTION
> Assistance disclosure: This pull request was implemented with OpenAI Codex. The diff was reviewed and verified against the project test and lint gates.

## Summary

- add `EqLitString` for CQL string comparisons without bind parameters
- escape embedded apostrophes by doubling them according to CQL string literal syntax
- keep `EqLit` as a raw literal API for UUIDs, numbers, and other non-string literals
- cover the original conditional update and embedded-apostrophe regressions

Fixes #199

## Testing

- `go test -race -count=1 ./qb`
- `go vet ./...`
- `golangci-lint v2.5.0 run ./...`
- Scylla-backed project test packages with `scylladb/scylla:6.2`
- `go test -race -count=1 ./cmd/schemagen` in a Go 1.25 Linux container sharing the Scylla network namespace
