### PR TITLE
schemagen: handle nested frozen UDT collections

### DIFF
--- a/cmd/schemagen/keyspace.tmpl
+++ b/cmd/schemagen/keyspace.tmpl
@@ -98,7 +98,7 @@ var (
 type {{$type_name}}UserType struct {
 	gocqlx.UDT
 {{- range $index, $element := .FieldNames}}
-	{{. | camelize}} {{(index $field_types $index) | mapScyllaToGoType}}
+	{{. | camelize}} {{(index $field_types $index) | mapScyllaToGoType}} `cql:"{{.}}"`
 {{- end}}
 }
 {{- end}}

--- a/cmd/schemagen/map_types.go
+++ b/cmd/schemagen/map_types.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"regexp"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -30,58 +30,131 @@ var types = map[string]string{
 	"varint":    "int64",
 }
 
-func mapScyllaToGoType(s string) string {
-	frozenRegex := regexp.MustCompile(`frozen<([a-z]*)>`)
-	match := frozenRegex.FindAllStringSubmatch(s, -1)
-	if match != nil {
-		s = match[0][1]
-	}
+func mapScyllaToGoType(s string) (string, error) {
+	t, _, err := goTypeForScyllaType(s, true)
+	return t, err
+}
 
-	mapRegex := regexp.MustCompile(`map<([a-z]*), ([a-z]*)>`)
-	setRegex := regexp.MustCompile(`set<([a-z]*)>`)
-	listRegex := regexp.MustCompile(`list<([a-z]*)>`)
-	tupleRegex := regexp.MustCompile(`tuple<(?:([a-z]*),? ?)*>`)
-	match = mapRegex.FindAllStringSubmatch(s, -1)
-	if match != nil {
-		key := match[0][1]
-		value := match[0][2]
-
-		return "map[" + types[key] + "]" + types[value]
-	}
-
-	match = setRegex.FindAllStringSubmatch(s, -1)
-	if match != nil {
-		key := match[0][1]
-
-		return "[]" + types[key]
-	}
-
-	match = listRegex.FindAllStringSubmatch(s, -1)
-	if match != nil {
-		key := match[0][1]
-
-		return "[]" + types[key]
-	}
-
-	match = tupleRegex.FindAllStringSubmatch(s, -1)
-	if match != nil {
-		tuple := match[0][0]
-		subStr := tuple[6 : len(tuple)-1]
-		types := strings.Split(subStr, ", ")
-
-		typeStr := "struct {\n"
-		for i, t := range types {
-			typeStr += "\t\tField" + strconv.Itoa(i+1) + " " + mapScyllaToGoType(t) + "\n"
-		}
-		typeStr += "\t}"
-
-		return typeStr
-	}
+func goTypeForScyllaType(s string, allowTuple bool) (goType string, isComparable bool, err error) {
+	s = strings.TrimSpace(s)
 
 	t, exists := types[s]
 	if exists {
-		return t
+		return t, isComparableGoType(t), nil
 	}
 
-	return camelize(s) + "UserType"
+	name, args, ok := splitTypeConstructor(s)
+	if ok {
+		if hasEmptyTypeArg(args) {
+			return "", false, fmt.Errorf("unsupported CQL type %q", s)
+		}
+
+		switch name {
+		case "frozen":
+			if len(args) == 1 {
+				return goTypeForScyllaType(args[0], false)
+			}
+		case "map":
+			if len(args) == 2 {
+				key, isComparable, err := goTypeForScyllaType(args[0], false)
+				if err != nil {
+					return "", false, err
+				}
+				if !isComparable {
+					return "", false, fmt.Errorf("unsupported non-comparable CQL map key type %q", args[0])
+				}
+				value, _, err := goTypeForScyllaType(args[1], false)
+				if err != nil {
+					return "", false, err
+				}
+				return "map[" + key + "]" + value, false, nil
+			}
+		case "set", "list":
+			if len(args) == 1 {
+				t, _, err := goTypeForScyllaType(args[0], false)
+				if err != nil {
+					return "", false, err
+				}
+				return "[]" + t, false, nil
+			}
+		case "tuple":
+			if !allowTuple {
+				return "", false, unsupportedTupleElementError(s)
+			}
+			isComparable = true
+			typeStr := "struct {\n"
+			for i, t := range args {
+				if _, _, ok := splitTypeConstructor(t); ok {
+					return "", false, unsupportedTupleElementError(s)
+				}
+				goType, fieldComparable, err := goTypeForScyllaType(t, false)
+				if err != nil {
+					return "", false, err
+				}
+				if !fieldComparable {
+					isComparable = false
+				}
+				typeStr += "\t\tField" + strconv.Itoa(i+1) + " " + goType + "\n"
+			}
+			typeStr += "\t}"
+
+			return typeStr, isComparable, nil
+		}
+
+		return "", false, fmt.Errorf("unsupported CQL type %q", s)
+	}
+
+	// Bare identifiers are treated as UDT references here. This parser does not
+	// have UDT metadata, so UDT field comparability is validated earlier by
+	// validateMapKeyTypes before templates call mapScyllaToGoType.
+	return camelize(s) + "UserType", true, nil
+}
+
+func unsupportedTupleElementError(s string) error {
+	return fmt.Errorf("unsupported non-flat tuple element CQL type %q; see https://github.com/scylladb/gocqlx/issues/375", s)
+}
+
+func isComparableGoType(s string) bool {
+	return !strings.HasPrefix(s, "[]") && s != "inf.Dec"
+}
+
+func splitTypeConstructor(s string) (name string, args []string, ok bool) {
+	start := strings.IndexByte(s, '<')
+	if start < 1 || !strings.HasSuffix(s, ">") {
+		return "", nil, false
+	}
+
+	return s[:start], splitTypeArgs(s[start+1 : len(s)-1]), true
+}
+
+func splitTypeArgs(s string) []string {
+	args := make([]string, 0, 2)
+	start := 0
+	depth := 0
+
+	for i, r := range s {
+		switch r {
+		case '<':
+			depth++
+		case '>':
+			depth--
+		case ',':
+			if depth == 0 {
+				args = append(args, strings.TrimSpace(s[start:i]))
+				start = i + 1
+			}
+		}
+	}
+
+	return append(args, strings.TrimSpace(s[start:]))
+}
+
+func hasEmptyTypeArg(args []string) bool {
+	for _, arg := range args {
+		if arg == "" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/cmd/schemagen/map_types_test.go
+++ b/cmd/schemagen/map_types_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -37,12 +38,94 @@ func TestMapScyllaToGoType(t *testing.T) {
 		{"map<int, text>", "map[int32]string"},
 		{"list<int>", "[]int32"},
 		{"set<int>", "[]int32"},
+		{"frozen<set<rcas>>", "[]RcasUserType"},
+		{"frozen<map<incidentcustomuserrole, set<userid>>>", "map[IncidentcustomuserroleUserType][]UseridUserType"},
+		{"map<text, frozen<list<album>>>", "map[string][]AlbumUserType"},
 		{"tuple<boolean, int, smallint>", "struct {\n\t\tField1 bool\n\t\tField2 int32\n\t\tField3 int16\n\t}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			if got := mapScyllaToGoType(tt.input); got != tt.want {
+			got, err := mapScyllaToGoType(tt.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
 				t.Errorf("mapScyllaToGoType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapScyllaToGoTypeRejectsNonComparableMapKeys(t *testing.T) {
+	tests := []string{
+		"map<blob, text>",
+		"map<decimal, text>",
+		"map<frozen<set<int>>, text>",
+	}
+	for _, tt := range tests {
+		t.Run(tt, func(t *testing.T) {
+			_, err := mapScyllaToGoType(tt)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "unsupported non-comparable CQL map key type") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestMapScyllaToGoTypeRejectsExpandedTupleShapes(t *testing.T) {
+	// These valid CQL shapes are intentionally rejected until gocqlx#375
+	// settles end-to-end generated tuple support.
+	// https://github.com/scylladb/gocqlx/issues/375
+	tests := []string{
+		"frozen<tuple<int>>",
+		"list<tuple<int>>",
+		"set<tuple<int>>",
+		"map<text, tuple<int>>",
+		"map<tuple<int>, text>",
+		"tuple<boolean, map<text, frozen<set<album>>>>",
+		"tuple<frozen<album>>",
+		"tuple<frozen<set<album>>>",
+		"tuple<list<int>>",
+		"tuple<tuple<int>>",
+	}
+	for _, tt := range tests {
+		t.Run(tt, func(t *testing.T) {
+			_, err := mapScyllaToGoType(tt)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "unsupported non-flat tuple element CQL type") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(err.Error(), "https://github.com/scylladb/gocqlx/issues/375") {
+				t.Fatalf("error does not include issue link: %v", err)
+			}
+		})
+	}
+}
+
+func TestMapScyllaToGoTypeRejectsUnsupportedConstructors(t *testing.T) {
+	tests := []string{
+		"vector<float, 3>",
+		"map<int>",
+		"map<int, text, boolean>",
+		"list<int, text>",
+		"frozen<>",
+	}
+	for _, tt := range tests {
+		t.Run(tt, func(t *testing.T) {
+			_, err := mapScyllaToGoType(tt)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "unsupported CQL type") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(err.Error(), tt) {
+				t.Fatalf("error does not include type %q: %v", tt, err)
 			}
 		})
 	}

--- a/cmd/schemagen/schemagen.go
+++ b/cmd/schemagen/schemagen.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -116,18 +115,9 @@ func renderTemplate(md *gocql.KeyspaceMetadata) ([]byte, error) {
 		delete(md.Indexes, name)
 	}
 
-	// Delete a user-defined type (UDT) if it is not used any column (i.e.
-	// table, view, or index).
-	orphanedTypes := make(map[string]struct{})
-	for userTypeName := range md.Types {
-		if !usedInTables(userTypeName, md.Tables) &&
-			!usedInViews(userTypeName, md.Views) &&
-			!usedInIndices(userTypeName, md.Indexes) {
-			orphanedTypes[userTypeName] = struct{}{}
-		}
-	}
-	for typeName := range orphanedTypes {
-		delete(md.Types, typeName)
+	removeUnusedUserTypes(md)
+	if err := validateMapKeyTypes(md); err != nil {
+		return nil, fmt.Errorf("validate map key types: %w", err)
 	}
 
 	imports := make([]string, 0)
@@ -135,17 +125,23 @@ func renderTemplate(md *gocql.KeyspaceMetadata) ([]byte, error) {
 		imports = append(imports, "github.com/scylladb/gocqlx/v3")
 	}
 
-	updateImports := func(columns map[string]*gocql.ColumnMetadata) {
-		for _, c := range columns {
-			if (c.Type == "timestamp" || c.Type == "date" || c.Type == "time") && !existsInSlice(imports, "time") {
+	updateImport := func(scyllaType string) {
+		for _, typeName := range scyllaTypeNames(scyllaType) {
+			if (typeName == "timestamp" || typeName == "date" || typeName == "time") && !existsInSlice(imports, "time") {
 				imports = append(imports, "time")
 			}
-			if c.Type == "decimal" && !existsInSlice(imports, "gopkg.in/inf.v0") {
+			if typeName == "decimal" && !existsInSlice(imports, "gopkg.in/inf.v0") {
 				imports = append(imports, "gopkg.in/inf.v0")
 			}
-			if c.Type == "duration" && !existsInSlice(imports, "github.com/gocql/gocql") {
+			if typeName == "duration" && !existsInSlice(imports, "github.com/gocql/gocql") {
 				imports = append(imports, "github.com/gocql/gocql")
 			}
+		}
+	}
+
+	updateImports := func(columns map[string]*gocql.ColumnMetadata) {
+		for _, c := range columns {
+			updateImport(c.Type)
 		}
 	}
 
@@ -164,6 +160,11 @@ func renderTemplate(md *gocql.KeyspaceMetadata) ([]byte, error) {
 	for _, i := range md.Indexes {
 		sort.Strings(i.OrderedColumns)
 		updateImports(i.Columns)
+	}
+	for _, userType := range md.Types {
+		for _, fieldType := range userType.FieldTypes {
+			updateImport(fieldType)
+		}
 	}
 
 	buf := &bytes.Buffer{}
@@ -225,25 +226,182 @@ func existsInSlice(s []string, v string) bool {
 	return false
 }
 
-// userTypes finds Cassandra schema types enclosed in angle brackets.
-// Calling FindAllStringSubmatch on it will return a slice of string slices containing two elements.
-// The second element contains the name of the type.
-//
-//	[["<my_type,", "my_type"] ["my_other_type>", "my_other_type"]]
-var userTypes = regexp.MustCompile(`(?:<|\s)(\w+)[>,]`) // match all types contained in set<X>, list<X>, tuple<A, B> etc.
+func removeUnusedUserTypes(md *gocql.KeyspaceMetadata) {
+	usedTypes := make(map[string]struct{})
+	for userTypeName := range md.Types {
+		if usedInTables(userTypeName, md.Tables) ||
+			usedInViews(userTypeName, md.Views) ||
+			usedInIndices(userTypeName, md.Indexes) {
+			addUsedUserType(userTypeName, md.Types, usedTypes)
+		}
+	}
+
+	for typeName := range md.Types {
+		if _, ok := usedTypes[typeName]; !ok {
+			delete(md.Types, typeName)
+		}
+	}
+}
+
+func addUsedUserType(typeName string, userTypes map[string]*gocql.TypeMetadata, usedTypes map[string]struct{}) {
+	if _, ok := usedTypes[typeName]; ok {
+		return
+	}
+
+	userType, ok := userTypes[typeName]
+	if !ok {
+		return
+	}
+
+	usedTypes[typeName] = struct{}{}
+	for _, fieldType := range userType.FieldTypes {
+		for _, fieldTypeName := range scyllaTypeNames(fieldType) {
+			addUsedUserType(fieldTypeName, userTypes, usedTypes)
+		}
+	}
+}
+
+func validateMapKeyTypes(md *gocql.KeyspaceMetadata) error {
+	validateColumns := func(source string, columns map[string]*gocql.ColumnMetadata) error {
+		for columnName, column := range columns {
+			if err := validateScyllaMapKeys(column.Type, md.Types); err != nil {
+				return fmt.Errorf("%s column %s: %w", source, columnName, err)
+			}
+		}
+		return nil
+	}
+
+	for tableName, table := range md.Tables {
+		if err := validateColumns("table "+tableName, table.Columns); err != nil {
+			return err
+		}
+	}
+	for viewName, view := range md.Views {
+		if err := validateColumns("view "+viewName, view.Columns); err != nil {
+			return err
+		}
+	}
+	for indexName, index := range md.Indexes {
+		if err := validateColumns("index "+indexName, index.Columns); err != nil {
+			return err
+		}
+	}
+	for typeName, userType := range md.Types {
+		for i, fieldType := range userType.FieldTypes {
+			if err := validateScyllaMapKeys(fieldType, md.Types); err != nil {
+				fieldName := fmt.Sprintf("%d", i)
+				if i < len(userType.FieldNames) {
+					fieldName = userType.FieldNames[i]
+				}
+				return fmt.Errorf("UDT %s field %s: %w", typeName, fieldName, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateScyllaMapKeys(s string, userTypes map[string]*gocql.TypeMetadata) error {
+	name, args, ok := splitTypeConstructor(strings.TrimSpace(s))
+	if !ok {
+		return nil
+	}
+
+	if name == "map" && len(args) == 2 && !isComparableScyllaType(args[0], userTypes, make(map[string]struct{})) {
+		return fmt.Errorf("unsupported non-comparable CQL map key type %q", args[0])
+	}
+
+	for _, arg := range args {
+		if err := validateScyllaMapKeys(arg, userTypes); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func isComparableScyllaType(s string, userTypes map[string]*gocql.TypeMetadata, seen map[string]struct{}) bool {
+	s = strings.TrimSpace(s)
+
+	if goType, ok := types[s]; ok {
+		return isComparableGoType(goType)
+	}
+
+	name, args, ok := splitTypeConstructor(s)
+	if ok {
+		switch name {
+		case "frozen":
+			return len(args) == 1 && isComparableScyllaType(args[0], userTypes, seen)
+		case "tuple":
+			for _, arg := range args {
+				if !isComparableScyllaType(arg, userTypes, seen) {
+					return false
+				}
+			}
+			return true
+		case "map", "set", "list":
+			return false
+		default:
+			return true
+		}
+	}
+
+	userType, ok := userTypes[s]
+	if !ok {
+		return true
+	}
+	if _, ok := seen[s]; ok {
+		return true
+	}
+
+	seen[s] = struct{}{}
+	defer delete(seen, s)
+
+	for _, fieldType := range userType.FieldTypes {
+		if !isComparableScyllaType(fieldType, userTypes, seen) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func scyllaTypeNames(s string) []string {
+	s = strings.TrimSpace(s)
+
+	name, args, ok := splitTypeConstructor(s)
+	if !ok {
+		return []string{s}
+	}
+
+	switch name {
+	case "frozen", "map", "set", "list", "tuple":
+		typeNames := make([]string, 0, len(args))
+		for _, arg := range args {
+			typeNames = append(typeNames, scyllaTypeNames(arg)...)
+		}
+		return typeNames
+	default:
+		return []string{s}
+	}
+}
+
+func referencesScyllaType(typeName, scyllaType string) bool {
+	for _, scyllaTypeName := range scyllaTypeNames(scyllaType) {
+		if scyllaTypeName == typeName {
+			return true
+		}
+	}
+
+	return false
+}
 
 // usedInColumns tests whether the typeName is used in any of columns of the
 // provided tables.
 func usedInColumns(typeName string, columns map[string]*gocql.ColumnMetadata) bool {
 	for _, column := range columns {
-		if typeName == column.Type {
+		if referencesScyllaType(typeName, column.Type) {
 			return true
-		}
-		matches := userTypes.FindAllStringSubmatch(column.Type, -1)
-		for _, s := range matches {
-			if s[1] == typeName {
-				return true
-			}
 		}
 	}
 	return false

--- a/cmd/schemagen/schemagen_test.go
+++ b/cmd/schemagen/schemagen_test.go
@@ -4,12 +4,14 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/gocql/gocql"
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/scylladb/gocqlx/v3"
 	"github.com/scylladb/gocqlx/v3/gocqlxtest"
 )
 
@@ -85,6 +87,10 @@ func Test_usedInTables(t *testing.T) {
 			columnValidator: "map<album, tuple<first, map<map_key, map-value>, third>>",
 			typeName:        "map_key",
 		},
+		"matches a nested map without spaces": {
+			columnValidator: "map<album,set<song>>",
+			typeName:        "song",
+		},
 	}
 
 	for name, tt := range tests {
@@ -108,6 +114,272 @@ func Test_usedInTables(t *testing.T) {
 		}
 		usedInTables("", tables)
 	})
+}
+
+func TestRenderTemplateRetainsNestedUserTypes(t *testing.T) {
+	pkgname := *flagPkgname
+	ignoreNames := *flagIgnoreNames
+	ignoreIndexes := *flagIgnoreIndexes
+	t.Cleanup(func() {
+		*flagPkgname = pkgname
+		*flagIgnoreNames = ignoreNames
+		*flagIgnoreIndexes = ignoreIndexes
+	})
+
+	*flagPkgname = "schemagentest"
+	*flagIgnoreNames = ""
+	*flagIgnoreIndexes = false
+
+	stateColumn := &gocql.ColumnMetadata{Name: "state", Type: "frozen<state>"}
+	b, err := renderTemplate(&gocql.KeyspaceMetadata{
+		Tables: map[string]*gocql.TableMetadata{
+			"states": {
+				Name:           "states",
+				Columns:        map[string]*gocql.ColumnMetadata{"state": stateColumn},
+				OrderedColumns: []string{"state"},
+				PartitionKey:   []*gocql.ColumnMetadata{stateColumn},
+			},
+		},
+		Types: map[string]*gocql.TypeMetadata{
+			"state": {
+				Name:       "state",
+				FieldNames: []string{"rca", "status", "rolecustom"},
+				FieldTypes: []string{
+					"frozen<set<rcas>>",
+					"frozen<incidentstatus>",
+					"frozen<map<incidentcustomuserrole, set<userid>>>",
+				},
+			},
+			"rcas": {
+				Name:       "rcas",
+				FieldNames: []string{"id", "created", "elapsed", "score"},
+				FieldTypes: []string{"text", "timestamp", "duration", "decimal"},
+			},
+			"incidentstatus": {
+				Name:       "incidentstatus",
+				FieldNames: []string{"id"},
+				FieldTypes: []string{"text"},
+			},
+			"incidentcustomuserrole": {
+				Name:       "incidentcustomuserrole",
+				FieldNames: []string{"id"},
+				FieldTypes: []string{"text"},
+			},
+			"userid": {
+				Name:       "userid",
+				FieldNames: []string{"id"},
+				FieldTypes: []string{"text"},
+			},
+			"orphan": {
+				Name:       "orphan",
+				FieldNames: []string{"id"},
+				FieldTypes: []string{"text"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	source := string(b)
+	normalizedSource := strings.Join(strings.Fields(source), " ")
+	for _, want := range []string{
+		"type StateUserType struct {",
+		"Rca []RcasUserType `cql:\"rca\"`",
+		"Status IncidentstatusUserType `cql:\"status\"`",
+		"Rolecustom map[IncidentcustomuserroleUserType][]UseridUserType `cql:\"rolecustom\"`",
+		`"github.com/gocql/gocql"`,
+		"type RcasUserType struct {",
+		"Id string `cql:\"id\"`",
+		"Created time.Time `cql:\"created\"`",
+		"Elapsed gocql.Duration `cql:\"elapsed\"`",
+		"Score inf.Dec `cql:\"score\"`",
+		"type IncidentstatusUserType struct {",
+		"type IncidentcustomuserroleUserType struct {",
+		"type UseridUserType struct {",
+		`"gopkg.in/inf.v0"`,
+		`"time"`,
+	} {
+		if !strings.Contains(normalizedSource, want) {
+			t.Fatalf("missing generated source %q:\n%s", want, source)
+		}
+	}
+	if strings.Contains(normalizedSource, "type OrphanUserType struct {") {
+		t.Fatalf("orphan UDT should not be generated:\n%s", source)
+	}
+}
+
+func TestRenderTemplateRejectsNonComparableMapKeys(t *testing.T) {
+	pkgname := *flagPkgname
+	ignoreNames := *flagIgnoreNames
+	ignoreIndexes := *flagIgnoreIndexes
+	t.Cleanup(func() {
+		*flagPkgname = pkgname
+		*flagIgnoreNames = ignoreNames
+		*flagIgnoreIndexes = ignoreIndexes
+	})
+
+	*flagPkgname = "schemagentest"
+	*flagIgnoreNames = ""
+	*flagIgnoreIndexes = false
+
+	tests := []struct {
+		name string
+		md   *gocql.KeyspaceMetadata
+		want string
+	}{
+		{
+			name: "collection key",
+			md: &gocql.KeyspaceMetadata{
+				Tables: map[string]*gocql.TableMetadata{
+					"bad_table": {
+						Name: "bad_table",
+						Columns: map[string]*gocql.ColumnMetadata{
+							"bad": &gocql.ColumnMetadata{Name: "bad", Type: "map<frozen<set<int>>, text>"},
+						},
+					},
+				},
+			},
+			want: `table bad_table column bad: unsupported non-comparable CQL map key type "frozen<set<int>>"`,
+		},
+		{
+			name: "UDT key with collection field",
+			md: &gocql.KeyspaceMetadata{
+				Tables: map[string]*gocql.TableMetadata{
+					"states": {
+						Name: "states",
+						Columns: map[string]*gocql.ColumnMetadata{
+							"state": &gocql.ColumnMetadata{Name: "state", Type: "state"},
+						},
+					},
+				},
+				Types: map[string]*gocql.TypeMetadata{
+					"state": {
+						Name:       "state",
+						FieldNames: []string{"roles"},
+						FieldTypes: []string{"map<role, text>"},
+					},
+					"role": {
+						Name:       "role",
+						FieldNames: []string{"ids"},
+						FieldTypes: []string{"set<text>"},
+					},
+				},
+			},
+			want: `UDT state field roles: unsupported non-comparable CQL map key type "role"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := renderTemplate(tt.md)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGeneratedUserTypesRoundTripNestedUDTs(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	rcasType := gocql.NewUDTType(4, "rcas", "", gocql.UDTField{Name: "id", Type: textType})
+	statusType := gocql.NewUDTType(4, "incidentstatus", "", gocql.UDTField{Name: "id", Type: textType})
+	roleType := gocql.NewUDTType(4, "incidentcustomuserrole", "", gocql.UDTField{Name: "id", Type: textType})
+	userIDType := gocql.NewUDTType(4, "userid", "", gocql.UDTField{Name: "id", Type: textType})
+	userIDSetType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeSet), nil, userIDType)
+	stateType := gocql.NewUDTType(4, "state", "",
+		gocql.UDTField{
+			Name: "rca",
+			Type: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeSet), nil, rcasType),
+		},
+		gocql.UDTField{Name: "status", Type: statusType},
+		gocql.UDTField{
+			Name: "rolecustom",
+			Type: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), roleType, userIDSetType),
+		},
+	)
+
+	original := generatedStateUserType{
+		Rca:    []generatedRcasUserType{{Id: "rca-1"}},
+		Status: generatedIncidentstatusUserType{Id: "status-1"},
+		Rolecustom: map[generatedIncidentcustomuserroleUserType][]generatedUseridUserType{
+			{Id: "role-1"}: {{Id: "user-1"}},
+		},
+	}
+
+	data, err := gocql.Marshal(stateType, newTestGocqlxUDT(original))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded generatedStateUserType
+	if err := gocql.Unmarshal(stateType, data, newTestGocqlxUDT(&decoded)); err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(original, decoded); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+type testGocqlxUDT struct {
+	field map[string]reflect.Value
+}
+
+func newTestGocqlxUDT(value interface{}) testGocqlxUDT {
+	v := reflect.ValueOf(value)
+	for v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	return testGocqlxUDT{
+		field: gocqlx.DefaultMapper.FieldMap(v),
+	}
+}
+
+func (u testGocqlxUDT) MarshalUDT(name string, info gocql.TypeInfo) ([]byte, error) {
+	value, ok := u.field[name]
+	if ok {
+		return gocql.Marshal(info, value.Interface())
+	}
+	return nil, nil
+}
+
+func (u testGocqlxUDT) UnmarshalUDT(name string, info gocql.TypeInfo, data []byte) error {
+	value, ok := u.field[name]
+	if ok {
+		return gocql.Unmarshal(info, data, value.Addr().Interface())
+	}
+	return nil
+}
+
+type generatedStateUserType struct {
+	gocqlx.UDT
+	Rca        []generatedRcasUserType                                               `cql:"rca"`
+	Status     generatedIncidentstatusUserType                                       `cql:"status"`
+	Rolecustom map[generatedIncidentcustomuserroleUserType][]generatedUseridUserType `cql:"rolecustom"`
+}
+
+type generatedRcasUserType struct {
+	gocqlx.UDT
+	Id string `cql:"id"`
+}
+
+type generatedIncidentstatusUserType struct {
+	gocqlx.UDT
+	Id string `cql:"id"`
+}
+
+type generatedIncidentcustomuserroleUserType struct {
+	gocqlx.UDT
+	Id string `cql:"id"`
+}
+
+type generatedUseridUserType struct {
+	gocqlx.UDT
+	Id string `cql:"id"`
 }
 
 func assertDiff(t *testing.T, actual []byte, goldenFile string) {
@@ -134,12 +406,11 @@ func createTestSchema(t *testing.T) {
 	session := gocqlxtest.CreateSession(t)
 	defer session.Close()
 
-	err := session.ExecStmt(`CREATE KEYSPACE IF NOT EXISTS schemagen WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`)
-	if err != nil {
+	if err := gocqlxtest.CreateKeyspaceIfNotExists(session, "schemagen"); err != nil {
 		t.Fatal("create keyspace:", err)
 	}
 
-	err = session.ExecStmt(`CREATE TABLE IF NOT EXISTS schemagen.songs (
+	err := session.ExecStmt(`CREATE TABLE IF NOT EXISTS schemagen.songs (
 		id uuid PRIMARY KEY,
 		title text,
 		album text,

--- a/cmd/schemagen/testdata/models.go
+++ b/cmd/schemagen/testdata/models.go
@@ -50,8 +50,8 @@ var (
 // User-defined types (UDT) structs.
 type AlbumUserType struct {
 	gocqlx.UDT
-	Name        string
-	Songwriters []string
+	Name        string   `cql:"name"`
+	Songwriters []string `cql:"songwriters"`
 }
 
 // Table structs.

--- a/cmd/schemagen/testdata/no_ignore_indexes/models.go
+++ b/cmd/schemagen/testdata/no_ignore_indexes/models.go
@@ -69,8 +69,8 @@ var (
 // User-defined types (UDT) structs.
 type AlbumUserType struct {
 	gocqlx.UDT
-	Name        string
-	Songwriters []string
+	Name        string   `cql:"name"`
+	Songwriters []string `cql:"songwriters"`
 }
 
 // Table structs.

--- a/example_test.go
+++ b/example_test.go
@@ -53,6 +53,13 @@ func TestExample(t *testing.T) {
 	unsetEmptyValues(t, session)
 }
 
+func createExampleKeyspace(t *testing.T, session gocqlx.Session) {
+	t.Helper()
+	if err := gocqlxtest.CreateKeyspaceIfNotExists(session, "examples"); err != nil {
+		t.Fatal("create keyspace:", err)
+	}
+}
+
 type Song struct {
 	ID     gocql.UUID
 	Title  string
@@ -76,15 +83,11 @@ type PlaylistItem struct {
 func basicCreateAndPopulateKeyspace(t *testing.T, session gocqlx.Session, keyspace string) {
 	t.Helper()
 
-	err := session.ExecStmt(fmt.Sprintf(
-		`CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`,
-		keyspace,
-	))
-	if err != nil {
+	if err := gocqlxtest.CreateKeyspaceIfNotExists(session, keyspace); err != nil {
 		t.Fatal("create keyspace:", err)
 	}
 
-	err = session.ExecStmt(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.songs (
+	err := session.ExecStmt(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.songs (
 		id uuid PRIMARY KEY,
 		title text,
 		album text,
@@ -167,10 +170,7 @@ func basicCreateAndPopulateKeyspace(t *testing.T, session gocqlx.Session, keyspa
 func createAndPopulateKeyspaceAllTypes(t *testing.T, session gocqlx.Session) {
 	t.Helper()
 
-	err := session.ExecStmt(`CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`)
-	if err != nil {
-		t.Fatal("create keyspace:", err)
-	}
+	createExampleKeyspace(t, session)
 
 	// generated with schemagen
 	type CheckTypesStruct struct {
@@ -199,7 +199,7 @@ func createAndPopulateKeyspaceAllTypes(t *testing.T, session gocqlx.Session) {
 		VarInt     int64
 	}
 
-	err = session.ExecStmt(`CREATE TABLE IF NOT EXISTS examples.check_types (
+	err := session.ExecStmt(`CREATE TABLE IF NOT EXISTS examples.check_types (
 		asci_i ascii,
 		big_int bigint,
 		blo_b blob,
@@ -351,12 +351,9 @@ func basicReadScyllaVersion(t *testing.T, session gocqlx.Session) {
 func datatypesBlob(t *testing.T, session gocqlx.Session) {
 	t.Helper()
 
-	err := session.ExecStmt(`CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`)
-	if err != nil {
-		t.Fatal("create keyspace:", err)
-	}
+	createExampleKeyspace(t, session)
 
-	err = session.ExecStmt(`CREATE TABLE IF NOT EXISTS examples.blobs(k int PRIMARY KEY, b blob, m map<text, blob>)`)
+	err := session.ExecStmt(`CREATE TABLE IF NOT EXISTS examples.blobs(k int PRIMARY KEY, b blob, m map<text, blob>)`)
 	if err != nil {
 		t.Fatal("create table:", err)
 	}
@@ -404,12 +401,9 @@ type Coordinates struct {
 func datatypesUserDefinedType(t *testing.T, session gocqlx.Session) {
 	t.Helper()
 
-	err := session.ExecStmt(`CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`)
-	if err != nil {
-		t.Fatal("create keyspace:", err)
-	}
+	createExampleKeyspace(t, session)
 
-	err = session.ExecStmt(`CREATE TYPE IF NOT EXISTS examples.coordinates(x int, y int)`)
+	err := session.ExecStmt(`CREATE TYPE IF NOT EXISTS examples.coordinates(x int, y int)`)
 	if err != nil {
 		t.Fatal("create type:", err)
 	}
@@ -460,12 +454,9 @@ type coordinates struct {
 func datatypesUserDefinedTypeWrapper(t *testing.T, session gocqlx.Session) {
 	t.Helper()
 
-	err := session.ExecStmt(`CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`)
-	if err != nil {
-		t.Fatal("create keyspace:", err)
-	}
+	createExampleKeyspace(t, session)
 
-	err = session.ExecStmt(`CREATE TYPE IF NOT EXISTS examples.coordinates(x int, y int)`)
+	err := session.ExecStmt(`CREATE TYPE IF NOT EXISTS examples.coordinates(x int, y int)`)
 	if err != nil {
 		t.Fatal("create type:", err)
 	}
@@ -518,12 +509,9 @@ func datatypesUserDefinedTypeWrapper(t *testing.T, session gocqlx.Session) {
 func datatypesJSON(t *testing.T, session gocqlx.Session) {
 	t.Helper()
 
-	err := session.ExecStmt(`CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`)
-	if err != nil {
-		t.Fatal("create keyspace:", err)
-	}
+	createExampleKeyspace(t, session)
 
-	err = session.ExecStmt(`CREATE TABLE IF NOT EXISTS examples.querybuilder_json(id int PRIMARY KEY, name text, specs map<text, text>)`)
+	err := session.ExecStmt(`CREATE TABLE IF NOT EXISTS examples.querybuilder_json(id int PRIMARY KEY, name text, specs map<text, text>)`)
 	if err != nil {
 		t.Fatal("create table:", err)
 	}
@@ -618,12 +606,9 @@ func pagingFillTable(t *testing.T, insert *gocqlx.Queryx) {
 func pagingForwardPaging(t *testing.T, session gocqlx.Session) {
 	t.Helper()
 
-	err := session.ExecStmt(`CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`)
-	if err != nil {
-		t.Fatal("create keyspace:", err)
-	}
+	createExampleKeyspace(t, session)
 
-	err = session.ExecStmt(`CREATE TABLE IF NOT EXISTS examples.paging_forward_paging(
+	err := session.ExecStmt(`CREATE TABLE IF NOT EXISTS examples.paging_forward_paging(
 		user_id int,
 		user_name text,
 		added timestamp,
@@ -689,12 +674,9 @@ func pagingForwardPaging(t *testing.T, session gocqlx.Session) {
 func pagingEfficientFullTableScan(t *testing.T, session gocqlx.Session) {
 	t.Helper()
 
-	err := session.ExecStmt(`CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`)
-	if err != nil {
-		t.Fatal("create keyspace:", err)
-	}
+	createExampleKeyspace(t, session)
 
-	err = session.ExecStmt(`CREATE TABLE IF NOT EXISTS examples.paging_efficient_full_table_scan(
+	err := session.ExecStmt(`CREATE TABLE IF NOT EXISTS examples.paging_efficient_full_table_scan(
 		user_id int,
 		user_name text,
 		added timestamp,
@@ -801,10 +783,7 @@ func pagingEfficientFullTableScan(t *testing.T, session gocqlx.Session) {
 func lwtLock(t *testing.T, session gocqlx.Session) {
 	t.Helper()
 
-	err := session.ExecStmt(`CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`)
-	if err != nil {
-		t.Fatal("create keyspace:", err)
-	}
+	createExampleKeyspace(t, session)
 
 	type Lock struct {
 		Name  string
@@ -812,7 +791,7 @@ func lwtLock(t *testing.T, session gocqlx.Session) {
 		TTL   int64
 	}
 
-	err = session.ExecStmt(`CREATE TABLE examples.lock (name text PRIMARY KEY, owner text)`)
+	err := session.ExecStmt(`CREATE TABLE examples.lock (name text PRIMARY KEY, owner text)`)
 	if err != nil {
 		t.Fatal("create table:", err)
 	}
@@ -902,10 +881,7 @@ func lwtLock(t *testing.T, session gocqlx.Session) {
 func unsetEmptyValues(t *testing.T, session gocqlx.Session) {
 	t.Helper()
 
-	err := session.ExecStmt(`CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`)
-	if err != nil {
-		t.Fatal("create keyspace:", err)
-	}
+	createExampleKeyspace(t, session)
 
 	type Operation struct {
 		ID        string
@@ -914,7 +890,7 @@ func unsetEmptyValues(t *testing.T, session gocqlx.Session) {
 		PaymentID string
 		Fee       *inf.Dec
 	}
-	err = session.ExecStmt(`CREATE TABLE IF NOT EXISTS examples.operations (
+	err := session.ExecStmt(`CREATE TABLE IF NOT EXISTS examples.operations (
 		id text PRIMARY KEY,
 		client_id text,
 		type text,

--- a/gocqlxtest/gocqlxtest.go
+++ b/gocqlxtest/gocqlxtest.go
@@ -90,13 +90,36 @@ func CreateKeyspace(cluster *gocql.ClusterConfig, keyspace string) error {
 	}
 
 	{
-		err := session.ExecStmt(fmt.Sprintf(`CREATE KEYSPACE %s WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : %d}`, keyspace, *flagRF))
-		if err != nil {
+		stmt := fmt.Sprintf(`CREATE KEYSPACE %s WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : %d}`, keyspace, *flagRF)
+		if err := execCreateKeyspaceStmt(session, stmt); err != nil {
 			return fmt.Errorf("create keyspace: %w", err)
 		}
 	}
 
 	return nil
+}
+
+// CreateKeyspaceIfNotExists creates keyspace with SimpleStrategy and RF derived from flags.
+func CreateKeyspaceIfNotExists(session gocqlx.Session, keyspace string) error {
+	stmt := fmt.Sprintf(`CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : %d}`, keyspace, *flagRF)
+	if err := execCreateKeyspaceStmt(session, stmt); err != nil {
+		return fmt.Errorf("create keyspace: %w", err)
+	}
+	return nil
+}
+
+type execStmtSession interface {
+	ExecStmt(stmt string) error
+}
+
+func execCreateKeyspaceStmt(session execStmtSession, stmt string) error {
+	err := session.ExecStmt(stmt)
+	if err == nil || !strings.Contains(err.Error(), "SimpleStrategy doesn't support tablet replication") {
+		return err
+	}
+
+	stmt = strings.TrimSuffix(strings.TrimSpace(stmt), ";")
+	return session.ExecStmt(stmt + ` AND tablets = {'enabled': false}`)
 }
 
 func createSessionFromCluster(tb testing.TB, cluster *gocql.ClusterConfig) gocqlx.Session {

--- a/gocqlxtest/gocqlxtest_test.go
+++ b/gocqlxtest/gocqlxtest_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2017 ScyllaDB
+// Use of this source code is governed by a ALv2-style
+// license that can be found in the LICENSE file.
+
+package gocqlxtest
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestExecCreateKeyspaceStmtRetriesWithTabletsDisabled(t *testing.T) {
+	tests := []struct {
+		name string
+		stmt string
+		want []string
+	}{
+		{
+			name: "create keyspace",
+			stmt: `CREATE KEYSPACE gocqlx_test WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : 1}`,
+			want: []string{
+				`CREATE KEYSPACE gocqlx_test WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : 1}`,
+				`CREATE KEYSPACE gocqlx_test WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : 1} AND tablets = {'enabled': false}`,
+			},
+		},
+		{
+			name: "create keyspace if not exists",
+			stmt: `CREATE KEYSPACE IF NOT EXISTS gocqlx_test WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : 1};`,
+			want: []string{
+				`CREATE KEYSPACE IF NOT EXISTS gocqlx_test WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : 1};`,
+				`CREATE KEYSPACE IF NOT EXISTS gocqlx_test WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : 1} AND tablets = {'enabled': false}`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := &recordingExecStmtSession{
+				errs: []error{
+					errors.New("SimpleStrategy doesn't support tablet replication"),
+					nil,
+				},
+			}
+
+			if err := execCreateKeyspaceStmt(session, tt.stmt); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(session.stmts, tt.want) {
+				t.Fatalf("ExecStmt calls = %#v, want %#v", session.stmts, tt.want)
+			}
+		})
+	}
+}
+
+type recordingExecStmtSession struct {
+	stmts []string
+	errs  []error
+}
+
+func (s *recordingExecStmtSession) ExecStmt(stmt string) error {
+	s.stmts = append(s.stmts, stmt)
+	if len(s.errs) == 0 {
+		return nil
+	}
+
+	err := s.errs[0]
+	s.errs = s.errs[1:]
+	return err
+}


### PR DESCRIPTION
Fixes #373

## Problem
schemagen parsed CQL field types with flat regexes, so nested frozen collection types that contain UDTs were reduced to the UDT name instead of preserving the collection shape. Schemas such as `frozen<set<rcas>>` and `frozen<map<incidentcustomuserrole, set<userid>>>` could generate invalid Go structs and drop UDTs that were only referenced through nested fields.

Some valid CQL map key shapes, such as frozen collections or UDTs containing collection fields, cannot be represented as Go map keys because the generated key type is not comparable. Emitting those types produced Go code that could not compile.

The CI test setup also used `SimpleStrategy` keyspaces directly. Newer `scylladb/scylla:latest` images reject that when tablet replication is enabled by default, so the test keyspace could fail before the suite created its tables.

## Reduced scope
This section is the source of truth for this PR. If a review suggestion conflicts with this scope, defer it to the linked follow-up issue or a separate PR instead of expanding this change.

During review, tuple-related bugs were found that prevent safely claiming end-to-end support for nested tuple shapes in generated structs:

- scylladb/gocql#956 tracks the gocql tuple unmarshal bug where tuple elements are decoded through generic temporary values and can panic when assigned into generated destination fields.
- #375 tracks the gocqlx/schemagen follow-up to support or explicitly reject nested tuple forms once the gocql behavior is fixed.

Because of these bugs, this PR intentionally keeps its supported scope to nested frozen UDT collections through `list`, `set`, and `map`, transitive UDT retention/import discovery, UDT field tags, and map-key comparability validation. Tuple parsing remains best-effort for existing schemagen behavior, but expanded tuple support is left to follow-up work.

## Changes
- replace flat regex type mapping with recursive parsing for `frozen`, `map`, `set`, and `list` constructors, while preserving existing best-effort tuple handling
- use parsed type names to retain transitive UDT dependencies and discover imports required by nested field types
- add `cql` tags to generated UDT fields so nested UDT values bind correctly
- reject non-comparable CQL map keys with an explicit schemagen error instead of generating invalid Go map types
- retry test keyspace creation with tablets disabled only when Scylla rejects `SimpleStrategy` tablet replication

