### PR TITLE
qb: quote mixed-case table names

### DIFF
--- a/qb/delete.go
+++ b/qb/delete.go
@@ -26,6 +26,7 @@ type DeleteBuilder struct {
 }
 
 // Delete returns a new DeleteBuilder with the given table name.
+// See the package documentation for table name quoting rules.
 func Delete(table string) *DeleteBuilder {
 	return &DeleteBuilder{
 		table: table,
@@ -42,7 +43,7 @@ func (b *DeleteBuilder) ToCql() (stmt string, names []string) {
 		cql.WriteByte(' ')
 	}
 	cql.WriteString("FROM ")
-	cql.WriteString(b.table)
+	cql.WriteString(quoteTableName(b.table))
 	cql.WriteByte(' ')
 
 	names = append(names, b.using.writeCql(&cql)...)
@@ -68,6 +69,7 @@ func (b *DeleteBuilder) QueryContext(ctx context.Context, session gocqlx.Session
 }
 
 // From sets the table to be deleted from.
+// See the package documentation for table name quoting rules.
 func (b *DeleteBuilder) From(table string) *DeleteBuilder {
 	b.table = table
 	return b

--- a/qb/delete_test.go
+++ b/qb/delete_test.go
@@ -28,7 +28,7 @@ func TestDeleteBuilder(t *testing.T) {
 		// Change table name
 		{
 			B: Delete("cycling.cyclist_name").Where(w).From("Foobar"),
-			S: "DELETE FROM Foobar WHERE id=? ",
+			S: `DELETE FROM "Foobar" WHERE id=? `,
 			N: []string{"expr"},
 		},
 		// Add column

--- a/qb/doc.go
+++ b/qb/doc.go
@@ -4,4 +4,12 @@
 
 // Package qb provides CQL query builders. The builders create CQL statement
 // and a list of named parameters that can later be bound using gocqlx.
+//
+// Table names passed to statement builders may be keyspace-qualified. Unquoted
+// identifiers that require CQL quoting, such as mixed-case names or reserved
+// keywords, are quoted automatically while already quoted identifiers are
+// preserved. This intentionally changes generated CQL for mixed-case unquoted
+// names: Foobar is rendered as "Foobar" instead of Foobar, preserving case
+// rather than relying on CQL's lowercase folding. Pass lowercase names when
+// targeting lowercase tables.
 package qb

--- a/qb/insert.go
+++ b/qb/insert.go
@@ -31,6 +31,7 @@ type InsertBuilder struct {
 }
 
 // Insert returns a new InsertBuilder with the given table name.
+// See the package documentation for table name quoting rules.
 func Insert(table string) *InsertBuilder {
 	return &InsertBuilder{
 		table: table,
@@ -44,7 +45,7 @@ func (b *InsertBuilder) ToCql() (stmt string, names []string) {
 	cql.WriteString("INSERT ")
 
 	cql.WriteString("INTO ")
-	cql.WriteString(b.table)
+	cql.WriteString(quoteTableName(b.table))
 	cql.WriteByte(' ')
 
 	if b.json {
@@ -92,6 +93,7 @@ func (b *InsertBuilder) QueryContext(ctx context.Context, session gocqlx.Session
 }
 
 // Into sets the INTO clause of the query.
+// See the package documentation for table name quoting rules.
 func (b *InsertBuilder) Into(table string) *InsertBuilder {
 	b.table = table
 	return b

--- a/qb/insert_test.go
+++ b/qb/insert_test.go
@@ -32,7 +32,7 @@ func TestInsertBuilder(t *testing.T) {
 		// Change table name
 		{
 			B: Insert("cycling.cyclist_name").Columns("id", "user_uuid", "firstname").Into("Foobar"),
-			S: "INSERT INTO Foobar (id,user_uuid,firstname) VALUES (?,?,?) ",
+			S: `INSERT INTO "Foobar" (id,user_uuid,firstname) VALUES (?,?,?) `,
 			N: []string{"id", "user_uuid", "firstname"},
 		},
 		// Add columns

--- a/qb/select.go
+++ b/qb/select.go
@@ -49,6 +49,7 @@ type SelectBuilder struct {
 }
 
 // Select returns a new SelectBuilder with the given table name.
+// See the package documentation for table name quoting rules.
 func Select(table string) *SelectBuilder {
 	return &SelectBuilder{
 		table: table,
@@ -81,7 +82,7 @@ func (b *SelectBuilder) ToCql() (stmt string, names []string) {
 		b.columns.writeCql(&cql)
 	}
 	cql.WriteString(" FROM ")
-	cql.WriteString(b.table)
+	cql.WriteString(quoteTableName(b.table))
 	cql.WriteByte(' ')
 
 	names = append(names, b.where.writeCql(&cql)...)
@@ -126,6 +127,7 @@ func (b *SelectBuilder) QueryContext(ctx context.Context, session gocqlx.Session
 }
 
 // From sets the table to be selected from.
+// See the package documentation for table name quoting rules.
 func (b *SelectBuilder) From(table string) *SelectBuilder {
 	b.table = table
 	return b

--- a/qb/select_test.go
+++ b/qb/select_test.go
@@ -58,7 +58,7 @@ func TestSelectBuilder(t *testing.T) {
 		// Change table name
 		{
 			B: Select("cycling.cyclist_name").From("Foobar"),
-			S: "SELECT * FROM Foobar ",
+			S: `SELECT * FROM "Foobar" `,
 		},
 		// Add WHERE
 		{

--- a/qb/update.go
+++ b/qb/update.go
@@ -41,6 +41,7 @@ type UpdateBuilder struct {
 }
 
 // Update returns a new UpdateBuilder with the given table name.
+// See the package documentation for table name quoting rules.
 func Update(table string) *UpdateBuilder {
 	return &UpdateBuilder{
 		table: table,
@@ -52,7 +53,7 @@ func (b *UpdateBuilder) ToCql() (stmt string, names []string) {
 	cql := bytes.Buffer{}
 
 	cql.WriteString("UPDATE ")
-	cql.WriteString(b.table)
+	cql.WriteString(quoteTableName(b.table))
 	cql.WriteByte(' ')
 
 	names = append(names, b.using.writeCql(&cql)...)
@@ -92,6 +93,7 @@ func (b *UpdateBuilder) QueryContext(ctx context.Context, session gocqlx.Session
 }
 
 // Table sets the table to be updated.
+// See the package documentation for table name quoting rules.
 func (b *UpdateBuilder) Table(table string) *UpdateBuilder {
 	b.table = table
 	return b

--- a/qb/update_test.go
+++ b/qb/update_test.go
@@ -28,7 +28,7 @@ func TestUpdateBuilder(t *testing.T) {
 		// Change table name
 		{
 			B: Update("cycling.cyclist_name").Set("id", "user_uuid", "firstname").Where(w).Table("Foobar"),
-			S: "UPDATE Foobar SET id=?,user_uuid=?,firstname=? WHERE id=? ",
+			S: `UPDATE "Foobar" SET id=?,user_uuid=?,firstname=? WHERE id=? `,
 			N: []string{"id", "user_uuid", "firstname", "expr"},
 		},
 		// Add SET

--- a/qb/utils.go
+++ b/qb/utils.go
@@ -35,6 +35,149 @@ func (cols columns) writeCql(cql *bytes.Buffer) {
 	}
 }
 
+func quoteTableName(table string) string {
+	if !strings.ContainsAny(table, `."`) {
+		return quoteIdentifier(table)
+	}
+
+	parts := splitTableName(table)
+	for i := range parts {
+		parts[i] = quoteIdentifier(parts[i])
+	}
+	return strings.Join(parts, ".")
+}
+
+func splitTableName(table string) []string {
+	var parts []string
+	start := 0
+	quoted := false
+
+	for i := 0; i < len(table); i++ {
+		switch table[i] {
+		case '"':
+			switch {
+			case quoted && i+1 < len(table) && table[i+1] == '"':
+				i++
+			case quoted:
+				quoted = false
+			case i == start:
+				quoted = true
+			}
+		case '.':
+			if !quoted {
+				parts = append(parts, table[start:i])
+				start = i + 1
+			}
+		}
+	}
+
+	return append(parts, table[start:])
+}
+
+func quoteIdentifier(identifier string) string {
+	if isQuotedIdentifier(identifier) || !needsQuoting(identifier) {
+		return identifier
+	}
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+}
+
+func isQuotedIdentifier(identifier string) bool {
+	if len(identifier) < 2 || identifier[0] != '"' || identifier[len(identifier)-1] != '"' {
+		return false
+	}
+
+	for i := 1; i < len(identifier)-1; i++ {
+		if identifier[i] != '"' {
+			continue
+		}
+		if i+1 < len(identifier)-1 && identifier[i+1] == '"' {
+			i++
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// Reserved words from ScyllaDB CQL Appendix A.
+var reservedCQLKeywords = map[string]struct{}{
+	"add":          {},
+	"allow":        {},
+	"alter":        {},
+	"and":          {},
+	"apply":        {},
+	"asc":          {},
+	"authorize":    {},
+	"batch":        {},
+	"begin":        {},
+	"by":           {},
+	"columnfamily": {},
+	"create":       {},
+	"delete":       {},
+	"desc":         {},
+	"describe":     {},
+	"drop":         {},
+	"entries":      {},
+	"execute":      {},
+	"from":         {},
+	"full":         {},
+	"grant":        {},
+	"if":           {},
+	"in":           {},
+	"index":        {},
+	"infinity":     {},
+	"insert":       {},
+	"into":         {},
+	"keyspace":     {},
+	"limit":        {},
+	"modify":       {},
+	"nan":          {},
+	"norecursive":  {},
+	"not":          {},
+	"null":         {},
+	"of":           {},
+	"on":           {},
+	"or":           {},
+	"order":        {},
+	"primary":      {},
+	"rename":       {},
+	"replace":      {},
+	"revoke":       {},
+	"schema":       {},
+	"select":       {},
+	"set":          {},
+	"table":        {},
+	"to":           {},
+	"token":        {},
+	"truncate":     {},
+	"unlogged":     {},
+	"update":       {},
+	"use":          {},
+	"using":        {},
+	"where":        {},
+	"with":         {},
+}
+
+func needsQuoting(identifier string) bool {
+	if identifier == "" {
+		return false
+	}
+
+	for i, r := range identifier {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9' && i > 0:
+		case r == '_' && i > 0:
+		default:
+			return true
+		}
+	}
+	if _, ok := reservedCQLKeywords[strings.ToLower(identifier)]; ok {
+		return true
+	}
+	return false
+}
+
 func formatDuration(d time.Duration) string {
 	// Round the duration to the nearest millisecond
 	// Extract hours, minutes, seconds, and milliseconds

--- a/qb/utils_test.go
+++ b/qb/utils_test.go
@@ -5,6 +5,83 @@ import (
 	"time"
 )
 
+func TestQuoteTableName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "simple qualified name",
+			in:   "cycling.cyclist_name",
+			want: "cycling.cyclist_name",
+		},
+		{
+			name: "mixed case table",
+			in:   "ks.tableName",
+			want: `ks."tableName"`,
+		},
+		{
+			name: "mixed case keyspace and table",
+			in:   "keySpace.tableName",
+			want: `"keySpace"."tableName"`,
+		},
+		{
+			name: "reserved keyword table",
+			in:   "ks.select",
+			want: `ks."select"`,
+		},
+		{
+			name: "reserved keyword keyspace",
+			in:   "select.tbl_name",
+			want: `"select".tbl_name`,
+		},
+		{
+			name: "non-reserved keyword table",
+			in:   "ks.aggregate",
+			want: `ks.aggregate`,
+		},
+		{
+			name: "already quoted table",
+			in:   `ks."tableName"`,
+			want: `ks."tableName"`,
+		},
+		{
+			name: "dot inside quoted keyspace",
+			in:   `"key.space".tableName`,
+			want: `"key.space"."tableName"`,
+		},
+		{
+			name: "quote inside unquoted keyspace",
+			in:   `key"space.tableName`,
+			want: `"key""space"."tableName"`,
+		},
+		{
+			name: "escaped quote inside quoted keyspace",
+			in:   `"key""space".tableName`,
+			want: `"key""space"."tableName"`,
+		},
+		{
+			name: "unescaped quote inside quoted table",
+			in:   `ks."table"name"`,
+			want: `ks."""table""name"""`,
+		},
+		{
+			name: "unescaped quotes inside quoted table",
+			in:   `"table"; DROP TABLE "other"`,
+			want: `"""table""; DROP TABLE ""other"""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := quoteTableName(tt.in); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatDuration(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/table/table.go
+++ b/table/table.go
@@ -13,6 +13,8 @@ import (
 
 // Metadata represents table schema.
 type Metadata struct {
+	// Name is the CQL table name. It may be keyspace-qualified; table builders
+	// apply qb table name quoting rules when rendering statements.
 	Name    string
 	Columns []string
 	PartKey []string

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -22,32 +22,32 @@ func TestTableGet(t *testing.T) {
 	}{
 		{
 			M: Metadata{
-				Name:    "table",
+				Name:    "tbl",
 				Columns: []string{"a", "b", "c", "d"},
 				PartKey: []string{"a"},
 				SortKey: []string{"b"},
 			},
 			N: []string{"a", "b"},
-			S: "SELECT * FROM table WHERE a=? AND b=? ",
+			S: "SELECT * FROM tbl WHERE a=? AND b=? ",
 		},
 		{
 			M: Metadata{
-				Name:    "table",
+				Name:    "tbl",
 				Columns: []string{"a", "b", "c", "d"},
 				PartKey: []string{"a"},
 			},
 			N: []string{"a"},
-			S: "SELECT * FROM table WHERE a=? ",
+			S: "SELECT * FROM tbl WHERE a=? ",
 		},
 		{
 			M: Metadata{
-				Name:    "table",
+				Name:    "tbl",
 				Columns: []string{"a", "b", "c", "d"},
 				PartKey: []string{"a"},
 			},
 			C: []string{"d"},
 			N: []string{"a"},
-			S: "SELECT d FROM table WHERE a=? ",
+			S: "SELECT d FROM tbl WHERE a=? ",
 		},
 	}
 
@@ -82,24 +82,24 @@ func TestTableSelect(t *testing.T) {
 	}{
 		{
 			M: Metadata{
-				Name:    "table",
+				Name:    "tbl",
 				Columns: []string{"a", "b", "c", "d"},
 				PartKey: []string{"a"},
 				SortKey: []string{"b"},
 			},
 			N: []string{"a"},
-			S: "SELECT * FROM table WHERE a=? ",
+			S: "SELECT * FROM tbl WHERE a=? ",
 		},
 		{
 			M: Metadata{
-				Name:    "table",
+				Name:    "tbl",
 				Columns: []string{"a", "b", "c", "d"},
 				PartKey: []string{"a"},
 				SortKey: []string{"b"},
 			},
 			C: []string{"d"},
 			N: []string{"a"},
-			S: "SELECT d FROM table WHERE a=? ",
+			S: "SELECT d FROM tbl WHERE a=? ",
 		},
 	}
 
@@ -133,13 +133,13 @@ func TestTableInsert(t *testing.T) {
 	}{
 		{
 			M: Metadata{
-				Name:    "table",
+				Name:    "tbl",
 				Columns: []string{"a", "b", "c", "d"},
 				PartKey: []string{"a"},
 				SortKey: []string{"b"},
 			},
 			N: []string{"a", "b", "c", "d"},
-			S: "INSERT INTO table (a,b,c,d) VALUES (?,?,?,?) ",
+			S: "INSERT INTO tbl (a,b,c,d) VALUES (?,?,?,?) ",
 		},
 	}
 
@@ -163,14 +163,14 @@ func TestTableUpdate(t *testing.T) {
 	}{
 		{
 			M: Metadata{
-				Name:    "table",
+				Name:    "tbl",
 				Columns: []string{"a", "b", "c", "d"},
 				PartKey: []string{"a"},
 				SortKey: []string{"b"},
 			},
 			C: []string{"d"},
 			N: []string{"d", "a", "b"},
-			S: "UPDATE table SET d=? WHERE a=? AND b=? ",
+			S: "UPDATE tbl SET d=? WHERE a=? AND b=? ",
 		},
 	}
 
@@ -205,32 +205,32 @@ func TestTableDelete(t *testing.T) {
 	}{
 		{
 			M: Metadata{
-				Name:    "table",
+				Name:    "tbl",
 				Columns: []string{"a", "b", "c", "d"},
 				PartKey: []string{"a"},
 				SortKey: []string{"b"},
 			},
 			N: []string{"a", "b"},
-			S: "DELETE FROM table WHERE a=? AND b=? ",
+			S: "DELETE FROM tbl WHERE a=? AND b=? ",
 		},
 		{
 			M: Metadata{
-				Name:    "table",
+				Name:    "tbl",
 				Columns: []string{"a", "b", "c", "d"},
 				PartKey: []string{"a"},
 			},
 			N: []string{"a"},
-			S: "DELETE FROM table WHERE a=? ",
+			S: "DELETE FROM tbl WHERE a=? ",
 		},
 		{
 			M: Metadata{
-				Name:    "table",
+				Name:    "tbl",
 				Columns: []string{"a", "b", "c", "d"},
 				PartKey: []string{"a"},
 			},
 			C: []string{"d"},
 			N: []string{"a"},
-			S: "DELETE d FROM table WHERE a=? ",
+			S: "DELETE d FROM tbl WHERE a=? ",
 		},
 	}
 
@@ -256,6 +256,61 @@ func TestTableDelete(t *testing.T) {
 	}
 }
 
+func TestTableQuotedName(t *testing.T) {
+	tbl := New(Metadata{
+		Name:    `ks.tableName`,
+		Columns: []string{"a", "b", "c", "d"},
+		PartKey: []string{"a"},
+		SortKey: []string{"b"},
+	})
+	stmtOnly := func(stmt string, _ []string) string {
+		return stmt
+	}
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "get",
+			got:  stmtOnly(tbl.Get()),
+			want: `SELECT * FROM ks."tableName" WHERE a=? AND b=? `,
+		},
+		{
+			name: "select",
+			got:  stmtOnly(tbl.Select()),
+			want: `SELECT * FROM ks."tableName" WHERE a=? `,
+		},
+		{
+			name: "select all",
+			got:  stmtOnly(tbl.SelectAll()),
+			want: `SELECT * FROM ks."tableName" `,
+		},
+		{
+			name: "insert",
+			got:  stmtOnly(tbl.Insert()),
+			want: `INSERT INTO ks."tableName" (a,b,c,d) VALUES (?,?,?,?) `,
+		},
+		{
+			name: "update",
+			got:  stmtOnly(tbl.Update("d")),
+			want: `UPDATE ks."tableName" SET d=? WHERE a=? AND b=? `,
+		},
+		{
+			name: "delete",
+			got:  stmtOnly(tbl.Delete()),
+			want: `DELETE FROM ks."tableName" WHERE a=? AND b=? `,
+		},
+	}
+
+	for _, tt := range tests {
+		if diff := cmp.Diff(tt.want, tt.got); diff != "" {
+			t.Errorf("%s stmt mismatch (-want +got):\n%s", tt.name, diff)
+		}
+	}
+}
+
 func TestTableConcurrentUsage(t *testing.T) {
 	table := []struct {
 		Name string
@@ -267,25 +322,25 @@ func TestTableConcurrentUsage(t *testing.T) {
 		{
 			Name: "Full select",
 			M: Metadata{
-				Name:    "table",
+				Name:    "tbl",
 				Columns: []string{"a", "b", "c", "d"},
 				PartKey: []string{"a"},
 				SortKey: []string{"b"},
 			},
 			N: []string{"a", "b"},
-			S: "SELECT * FROM table WHERE a=? AND b=? ",
+			S: "SELECT * FROM tbl WHERE a=? AND b=? ",
 		},
 		{
 			Name: "Sub select",
 			M: Metadata{
-				Name:    "table",
+				Name:    "tbl",
 				Columns: []string{"a", "b", "c", "d"},
 				PartKey: []string{"a"},
 				SortKey: []string{"b"},
 			},
 			C: []string{"d"},
 			N: []string{"a", "b"},
-			S: "SELECT d FROM table WHERE a=? AND b=? ",
+			S: "SELECT d FROM tbl WHERE a=? AND b=? ",
 		},
 	}
 


### PR DESCRIPTION
## Changes
- Quote table name segments that need CQL quoting before rendering SELECT, INSERT, UPDATE, and DELETE statements.
- Preserve lowercase identifiers and already quoted table names for compatibility.
- Add coverage for keyspace-qualified mixed-case table names via table CRUD helpers.

Fixes #168

## Testing
- go test ./qb ./table
- go test $(go list ./... | rg -v '/cmd/schemagen$')
- go test ./... (fails: cmd/schemagen requires Scylla/Cassandra on 127.0.0.1:9042)