### PR TITLE
qb: add quoted string literal helpers

### DIFF
--- a/qb/cmp.go
+++ b/qb/cmp.go
@@ -103,11 +103,22 @@ func EqTupleNamed(column string, count int, name string) Cmp {
 }
 
 // EqLit produces column=literal and does not add a parameter to the query.
+// The literal is written verbatim; use EqLitString for string values.
 func EqLit(column, literal string) Cmp {
 	return Cmp{
 		op:     eq,
 		column: column,
 		value:  lit(literal),
+	}
+}
+
+// EqLitString produces column='literal' with an escaped CQL string literal.
+// It does not add a parameter to the query.
+func EqLitString(column, literal string) Cmp {
+	return Cmp{
+		op:     eq,
+		column: column,
+		value:  stringLit(literal),
 	}
 }
 
@@ -163,11 +174,22 @@ func NeTupleNamed(column string, count int, name string) Cmp {
 }
 
 // NeLit produces column!=literal and does not add a parameter to the query.
+// The literal is written verbatim; use NeLitString for string values.
 func NeLit(column, literal string) Cmp {
 	return Cmp{
 		op:     ne,
 		column: column,
 		value:  lit(literal),
+	}
+}
+
+// NeLitString produces column!='literal' with an escaped CQL string literal.
+// It does not add a parameter to the query.
+func NeLitString(column, literal string) Cmp {
+	return Cmp{
+		op:     ne,
+		column: column,
+		value:  stringLit(literal),
 	}
 }
 
@@ -223,11 +245,22 @@ func LtTupleNamed(column string, count int, name string) Cmp {
 }
 
 // LtLit produces column<literal and does not add a parameter to the query.
+// The literal is written verbatim; use LtLitString for string values.
 func LtLit(column, literal string) Cmp {
 	return Cmp{
 		op:     lt,
 		column: column,
 		value:  lit(literal),
+	}
+}
+
+// LtLitString produces column<'literal' with an escaped CQL string literal.
+// It does not add a parameter to the query.
+func LtLitString(column, literal string) Cmp {
+	return Cmp{
+		op:     lt,
+		column: column,
+		value:  stringLit(literal),
 	}
 }
 
@@ -283,11 +316,22 @@ func LtOrEqTupleNamed(column string, count int, name string) Cmp {
 }
 
 // LtOrEqLit produces column<=literal and does not add a parameter to the query.
+// The literal is written verbatim; use LtOrEqLitString for string values.
 func LtOrEqLit(column, literal string) Cmp {
 	return Cmp{
 		op:     leq,
 		column: column,
 		value:  lit(literal),
+	}
+}
+
+// LtOrEqLitString produces column<='literal' with an escaped CQL string literal.
+// It does not add a parameter to the query.
+func LtOrEqLitString(column, literal string) Cmp {
+	return Cmp{
+		op:     leq,
+		column: column,
+		value:  stringLit(literal),
 	}
 }
 
@@ -343,11 +387,22 @@ func GtTupleNamed(column string, count int, name string) Cmp {
 }
 
 // GtLit produces column>literal and does not add a parameter to the query.
+// The literal is written verbatim; use GtLitString for string values.
 func GtLit(column, literal string) Cmp {
 	return Cmp{
 		op:     gt,
 		column: column,
 		value:  lit(literal),
+	}
+}
+
+// GtLitString produces column>'literal' with an escaped CQL string literal.
+// It does not add a parameter to the query.
+func GtLitString(column, literal string) Cmp {
+	return Cmp{
+		op:     gt,
+		column: column,
+		value:  stringLit(literal),
 	}
 }
 
@@ -403,11 +458,22 @@ func GtOrEqTupleNamed(column string, count int, name string) Cmp {
 }
 
 // GtOrEqLit produces column>=literal and does not add a parameter to the query.
+// The literal is written verbatim; use GtOrEqLitString for string values.
 func GtOrEqLit(column, literal string) Cmp {
 	return Cmp{
 		op:     geq,
 		column: column,
 		value:  lit(literal),
+	}
+}
+
+// GtOrEqLitString produces column>='literal' with an escaped CQL string literal.
+// It does not add a parameter to the query.
+func GtOrEqLitString(column, literal string) Cmp {
+	return Cmp{
+		op:     geq,
+		column: column,
+		value:  stringLit(literal),
 	}
 }
 
@@ -463,11 +529,33 @@ func InTupleNamed(column string, count int, name string) Cmp {
 }
 
 // InLit produces column IN literal and does not add a parameter to the query.
+// The literal is written verbatim; use InLitString or InLitStrings for string values.
 func InLit(column, literal string) Cmp {
 	return Cmp{
 		op:     in,
 		column: column,
 		value:  lit(literal),
+	}
+}
+
+// InLitString produces column IN ('literal') with an escaped CQL string literal.
+// It does not add a parameter to the query.
+func InLitString(column, literal string) Cmp {
+	return InLitStrings(column, literal)
+}
+
+// InLitStrings produces column IN ('literal',...) with escaped CQL string literals.
+// It does not add parameters to the query.
+// It panics if literals is empty.
+func InLitStrings(column string, literals ...string) Cmp {
+	if len(literals) == 0 {
+		panic("qb: InLitStrings requires at least one literal")
+	}
+
+	return Cmp{
+		op:     in,
+		column: column,
+		value:  stringListLit(literals),
 	}
 }
 
@@ -556,11 +644,42 @@ func ContainsKeyTupleNamed(column string, count int, name string) Cmp {
 }
 
 // ContainsLit produces column CONTAINS literal and does not add a parameter to the query.
+// The literal is written verbatim; use ContainsLitString for string values.
 func ContainsLit(column, literal string) Cmp {
 	return Cmp{
 		op:     cnt,
 		column: column,
 		value:  lit(literal),
+	}
+}
+
+// ContainsLitString produces column CONTAINS 'literal' with an escaped CQL string literal.
+// It does not add a parameter to the query.
+func ContainsLitString(column, literal string) Cmp {
+	return Cmp{
+		op:     cnt,
+		column: column,
+		value:  stringLit(literal),
+	}
+}
+
+// ContainsKeyLit produces column CONTAINS KEY literal and does not add a parameter to the query.
+// The literal is written verbatim; use ContainsKeyLitString for string values.
+func ContainsKeyLit(column, literal string) Cmp {
+	return Cmp{
+		op:     cntKey,
+		column: column,
+		value:  lit(literal),
+	}
+}
+
+// ContainsKeyLitString produces column CONTAINS KEY 'literal' with an escaped CQL string literal.
+// It does not add a parameter to the query.
+func ContainsKeyLitString(column, literal string) Cmp {
+	return Cmp{
+		op:     cntKey,
+		column: column,
+		value:  stringLit(literal),
 	}
 }
 
@@ -570,6 +689,26 @@ func Like(column string) Cmp {
 		op:     like,
 		column: column,
 		value:  param(column),
+	}
+}
+
+// LikeLit produces column LIKE literal and does not add a parameter to the query.
+// The literal is written verbatim; use LikeLitString for string values.
+func LikeLit(column, literal string) Cmp {
+	return Cmp{
+		op:     like,
+		column: column,
+		value:  lit(literal),
+	}
+}
+
+// LikeLitString produces column LIKE 'literal' with an escaped CQL string literal.
+// It does not add a parameter to the query.
+func LikeLitString(column, literal string) Cmp {
+	return Cmp{
+		op:     like,
+		column: column,
+		value:  stringLit(literal),
 	}
 }
 

--- a/qb/cmp_test.go
+++ b/qb/cmp_test.go
@@ -218,32 +218,84 @@ func TestCmp(t *testing.T) {
 			S: "eq=litval",
 		},
 		{
+			C: EqLitString("eq", "O'Brien"),
+			S: "eq='O''Brien'",
+		},
+		{
 			C: NeLit("ne", "litval"),
 			S: "ne!=litval",
+		},
+		{
+			C: NeLitString("ne", "O'Brien"),
+			S: "ne!='O''Brien'",
 		},
 		{
 			C: LtLit("lt", "litval"),
 			S: "lt<litval",
 		},
 		{
+			C: LtLitString("lt", "O'Brien"),
+			S: "lt<'O''Brien'",
+		},
+		{
 			C: LtOrEqLit("lt", "litval"),
 			S: "lt<=litval",
+		},
+		{
+			C: LtOrEqLitString("lt", "O'Brien"),
+			S: "lt<='O''Brien'",
 		},
 		{
 			C: GtLit("gt", "litval"),
 			S: "gt>litval",
 		},
 		{
+			C: GtLitString("gt", "O'Brien"),
+			S: "gt>'O''Brien'",
+		},
+		{
 			C: GtOrEqLit("gt", "litval"),
 			S: "gt>=litval",
+		},
+		{
+			C: GtOrEqLitString("gt", "O'Brien"),
+			S: "gt>='O''Brien'",
 		},
 		{
 			C: InLit("in", "litval"),
 			S: "in IN litval",
 		},
 		{
+			C: InLitString("in", "O'Brien"),
+			S: "in IN ('O''Brien')",
+		},
+		{
+			C: InLitStrings("in", "O'Brien", "RUNNING"),
+			S: "in IN ('O''Brien','RUNNING')",
+		},
+		{
 			C: ContainsLit("cnt", "litval"),
 			S: "cnt CONTAINS litval",
+		},
+		{
+			C: ContainsLitString("cnt", "O'Brien"),
+			S: "cnt CONTAINS 'O''Brien'",
+		},
+		{
+			C: ContainsKeyLit("cntKey", "litval"),
+			S: "cntKey CONTAINS KEY litval",
+		},
+		{
+			C: ContainsKeyLitString("cntKey", "O'Brien"),
+			S: "cntKey CONTAINS KEY 'O''Brien'",
+		},
+		{
+			C: LikeLit("like", "litval"),
+			S: "like LIKE litval",
+		},
+		{
+			C: LikeLitString("like", "O'B%"),
+			S: "like LIKE 'O''B%'",
 		},
 
 		// Functions
@@ -302,4 +354,14 @@ func TestCmp(t *testing.T) {
 			t.Error(diff)
 		}
 	}
+}
+
+func TestInLitStringsRequiresLiteral(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("InLitStrings() should panic with no literals")
+		}
+	}()
+
+	InLitStrings("in")
 }

--- a/qb/insert.go
+++ b/qb/insert.go
@@ -124,10 +124,21 @@ func (b *InsertBuilder) NamedColumn(column, name string) *InsertBuilder {
 }
 
 // LitColumn adds an insert column with a literal value to the query.
+// The literal is written verbatim; use StringLitColumn for string values.
 func (b *InsertBuilder) LitColumn(column, literal string) *InsertBuilder {
 	b.columns = append(b.columns, initializer{
 		column: column,
 		value:  lit(literal),
+	})
+	return b
+}
+
+// StringLitColumn adds an insert column with an escaped CQL string literal value.
+// It does not add a parameter to the query.
+func (b *InsertBuilder) StringLitColumn(column, literal string) *InsertBuilder {
+	b.columns = append(b.columns, initializer{
+		column: column,
+		value:  stringLit(literal),
 	})
 	return b
 }

--- a/qb/insert_test.go
+++ b/qb/insert_test.go
@@ -53,6 +53,12 @@ func TestInsertBuilder(t *testing.T) {
 			S: "INSERT INTO cycling.cyclist_name (id,user_uuid,firstname,stars) VALUES (?,?,?,stars_lit) ",
 			N: []string{"id", "user_uuid", "firstname"},
 		},
+		// Add a string literal column
+		{
+			B: Insert("cycling.cyclist_name").Columns("id", "user_uuid").StringLitColumn("firstname", "O'Brien"),
+			S: "INSERT INTO cycling.cyclist_name (id,user_uuid,firstname) VALUES (?,?,'O''Brien') ",
+			N: []string{"id", "user_uuid"},
+		},
 		// Add TTL
 		{
 			B: Insert("cycling.cyclist_name").Columns("id", "user_uuid", "firstname").TTL(time.Second),

--- a/qb/string_literal_integration_test.go
+++ b/qb/string_literal_integration_test.go
@@ -1,0 +1,176 @@
+// Copyright (C) 2017 ScyllaDB
+// Use of this source code is governed by a ALv2-style
+// license that can be found in the LICENSE file.
+
+//go:build all || integration
+// +build all integration
+
+package qb_test
+
+import (
+	"testing"
+
+	"github.com/scylladb/gocqlx/v3/gocqlxtest"
+	"github.com/scylladb/gocqlx/v3/qb"
+	"github.com/scylladb/gocqlx/v3/table"
+)
+
+func TestStringLiteralHelpersIntegration(t *testing.T) {
+	session := gocqlxtest.CreateSession(t)
+	defer session.Close()
+
+	const taskTableName = "qb_string_literal_tasks"
+	if err := session.ExecStmt(`DROP TABLE IF EXISTS ` + taskTableName); err != nil {
+		t.Fatal("drop task table:", err)
+	}
+	if err := session.ExecStmt(`CREATE TABLE ` + taskTableName + ` (
+		id int PRIMARY KEY,
+		status text,
+		note text,
+		tags set<text>,
+		attrs map<text, text>
+	)`); err != nil {
+		t.Fatal("create task table:", err)
+	}
+	if err := session.ExecStmt(`CREATE INDEX ` + taskTableName + `_tags_idx ON ` + taskTableName + ` (tags)`); err != nil {
+		t.Fatal("create tags index:", err)
+	}
+	if err := session.ExecStmt(`CREATE INDEX ` + taskTableName + `_attrs_keys_idx ON ` + taskTableName + ` (keys(attrs))`); err != nil {
+		t.Fatal("create attrs keys index:", err)
+	}
+
+	taskTable := table.New(table.Metadata{
+		Name:    taskTableName,
+		Columns: []string{"id", "status", "note", "tags", "attrs"},
+		PartKey: []string{"id"},
+	})
+
+	err := qb.Insert(taskTableName).
+		Columns("id", "tags", "attrs").
+		StringLitColumn("status", "O'Brien").
+		StringLitColumn("note", "initial").
+		Query(session).
+		BindMap(qb.M{
+			"id":    1,
+			"tags":  []string{"urgent", "O'Brien"},
+			"attrs": map[string]string{"O'Brien": "owner"},
+		}).
+		ExecRelease()
+	if err != nil {
+		t.Fatal("insert string literals:", err)
+	}
+
+	var status string
+	err = qb.Select(taskTableName).
+		Columns("status").
+		Where(qb.EqLit("id", "1")).
+		Query(session).
+		Get(&status)
+	if err != nil {
+		t.Fatal("select inserted status:", err)
+	}
+	if status != "O'Brien" {
+		t.Fatalf("status = %q, want %q", status, "O'Brien")
+	}
+
+	err = qb.Update(taskTableName).
+		SetLitString("status", "RUNNING").
+		SetLitString("note", "ready").
+		Where(qb.EqLit("id", "1")).
+		Query(session).
+		ExecRelease()
+	if err != nil {
+		t.Fatal("update string literals:", err)
+	}
+
+	applied, err := taskTable.UpdateBuilder("status").
+		If(qb.EqLitString("status", "RUNNING")).
+		Query(session).
+		BindMap(qb.M{
+			"id":     1,
+			"status": "DONE",
+		}).
+		ExecCASRelease()
+	if err != nil {
+		t.Fatal("table update IF string literal:", err)
+	}
+	if !applied {
+		t.Fatal("table update IF string literal was not applied")
+	}
+
+	applied, err = qb.Update(taskTableName).
+		SetLitString("note", "matched").
+		Where(qb.EqLit("id", "1")).
+		If(
+			qb.NeLitString("status", "RUNNING"),
+			qb.GtLitString("status", "A"),
+			qb.GtOrEqLitString("status", "DONE"),
+			qb.LtLitString("status", "ZZZ"),
+			qb.LtOrEqLitString("status", "DONE"),
+		).
+		Query(session).
+		ExecCASRelease()
+	if err != nil {
+		t.Fatal("conditional string literal comparisons:", err)
+	}
+	if !applied {
+		t.Fatal("conditional string literal comparisons were not applied")
+	}
+
+	var id int
+	err = qb.Select(taskTableName).
+		Columns("id").
+		Where(qb.ContainsLitString("tags", "O'Brien")).
+		Query(session).
+		Get(&id)
+	if err != nil {
+		t.Fatal("select CONTAINS string literal:", err)
+	}
+	if id != 1 {
+		t.Fatalf("CONTAINS id = %d, want 1", id)
+	}
+
+	err = qb.Select(taskTableName).
+		Columns("id").
+		Where(qb.ContainsKeyLitString("attrs", "O'Brien")).
+		Query(session).
+		Get(&id)
+	if err != nil {
+		t.Fatal("select CONTAINS KEY string literal:", err)
+	}
+	if id != 1 {
+		t.Fatalf("CONTAINS KEY id = %d, want 1", id)
+	}
+
+	const keyTableName = "qb_string_literal_keys"
+	if err := session.ExecStmt(`DROP TABLE IF EXISTS ` + keyTableName); err != nil {
+		t.Fatal("drop key table:", err)
+	}
+	if err := session.ExecStmt(`CREATE TABLE ` + keyTableName + ` (
+		id text PRIMARY KEY,
+		status text
+	)`); err != nil {
+		t.Fatal("create key table:", err)
+	}
+
+	err = qb.Insert(keyTableName).
+		StringLitColumn("id", "O'Brien").
+		StringLitColumn("status", "matched").
+		Query(session).
+		ExecRelease()
+	if err != nil {
+		t.Fatal("insert text primary key:", err)
+	}
+
+	err = qb.Select(keyTableName).
+		Columns("status").
+		Where(qb.InLitStrings("id", "missing", "O'Brien")).
+		Query(session).
+		Get(&status)
+	if err != nil {
+		t.Fatal("select IN string literals:", err)
+	}
+	if status != "matched" {
+		t.Fatalf("IN status = %q, want %q", status, "matched")
+	}
+}

--- a/qb/update.go
+++ b/qb/update.go
@@ -156,9 +156,18 @@ func (b *UpdateBuilder) SetNamed(column, name string) *UpdateBuilder {
 }
 
 // SetLit adds SET column=literal clause to the query.
+// The literal is written verbatim; use SetLitString for string values.
 func (b *UpdateBuilder) SetLit(column, literal string) *UpdateBuilder {
 	b.assignments = append(
 		b.assignments, assignment{column: column, value: lit(literal)})
+	return b
+}
+
+// SetLitString adds SET column='literal' with an escaped CQL string literal.
+// It does not add a parameter to the query.
+func (b *UpdateBuilder) SetLitString(column, literal string) *UpdateBuilder {
+	b.assignments = append(
+		b.assignments, assignment{column: column, value: stringLit(literal)})
 	return b
 }
 

--- a/qb/update_test.go
+++ b/qb/update_test.go
@@ -43,6 +43,12 @@ func TestUpdateBuilder(t *testing.T) {
 			S: "UPDATE cycling.cyclist_name SET user_uuid=literal_uuid,stars=? WHERE id=? ",
 			N: []string{"stars", "expr"},
 		},
+		// Add SET string literal
+		{
+			B: Update("cycling.cyclist_name").SetLitString("firstname", "O'Brien").Where(w),
+			S: "UPDATE cycling.cyclist_name SET firstname='O''Brien' WHERE id=? ",
+			N: []string{"expr"},
+		},
 
 		// Add SET tuple
 		{
@@ -103,6 +109,12 @@ func TestUpdateBuilder(t *testing.T) {
 			B: Update("cycling.cyclist_name").Set("id", "user_uuid", "firstname").Where(w).If(Gt("firstname")),
 			S: "UPDATE cycling.cyclist_name SET id=?,user_uuid=?,firstname=? WHERE id=? IF firstname>? ",
 			N: []string{"id", "user_uuid", "firstname", "expr", "firstname"},
+		},
+		// Add IF string literal
+		{
+			B: Update("scheduler_task_run").Set("status").Where(w).If(EqLitString("status", "RUNNING")),
+			S: "UPDATE scheduler_task_run SET status=? WHERE id=? IF status='RUNNING' ",
+			N: []string{"status", "expr"},
 		},
 		// Add TTL
 		{

--- a/qb/value.go
+++ b/qb/value.go
@@ -7,6 +7,7 @@ package qb
 import (
 	"bytes"
 	"strconv"
+	"strings"
 )
 
 // value is a CQL value expression for use in an initializer, assignment,
@@ -52,4 +53,33 @@ type lit string
 func (l lit) writeCql(cql *bytes.Buffer) (names []string) {
 	cql.WriteString(string(l))
 	return nil
+}
+
+// stringLit is a quoted CQL string literal.
+type stringLit string
+
+func (l stringLit) writeCql(cql *bytes.Buffer) (names []string) {
+	writeCqlString(cql, string(l))
+	return nil
+}
+
+// stringListLit is a parenthesized list of quoted CQL string literals.
+type stringListLit []string
+
+func (l stringListLit) writeCql(cql *bytes.Buffer) (names []string) {
+	cql.WriteByte('(')
+	for i, s := range l {
+		writeCqlString(cql, s)
+		if i < len(l)-1 {
+			cql.WriteByte(',')
+		}
+	}
+	cql.WriteByte(')')
+	return nil
+}
+
+func writeCqlString(cql *bytes.Buffer, s string) {
+	cql.WriteByte('\'')
+	cql.WriteString(strings.ReplaceAll(s, "'", "''"))
+	cql.WriteByte('\'')
 }


### PR DESCRIPTION
## Summary
- keep raw `*Lit` APIs verbatim and add explicit quoted string literal helpers for comparisons
- add string literal helpers for INSERT columns and UPDATE SET assignments
- cover the reported table `UpdateBuilder(...).If(qb.EqLitString(...))` path with live Scylla integration coverage

Fixes #199

## Testing
- `go test ./qb`
- `go test -cover ./qb`
- `go test -tags integration ./qb`
- `go test -tags integration -cover ./qb`
- `go test ./...`
- `go test -p 1 -count=1 -cover -tags all . ./qb ./table ./migrate ./dbutil ./cmd/schemagen`
- `go test -count=1 -cover -tags all .` in `cmd/schemagen/testdata`
- `go test -p 1 -count=1 -cover -race -tags all . ./qb ./table ./migrate ./dbutil ./cmd/schemagen`
- `go test -count=1 -cover -race -tags all .` in `cmd/schemagen/testdata`
- `make check`
