### PR TITLE
tuple: support arrays and slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,37 @@ fmt.Println(people)
 // stdout: [{Michał Matczuk [michal@scylladb.com]}]
 ```
 
+Bind and scan tuple columns with non-byte arrays, slices, or tuple-shaped
+structs:
+
+```go
+type Place struct {
+	ID         int
+	Coordinate [2]float64
+}
+
+insert := qb.Insert("place").Columns("id").TupleColumn("coordinate", 2).Query(session)
+if err := insert.BindStruct(Place{
+	ID:         1,
+	Coordinate: [2]float64{50.06, 19.94},
+}).ExecRelease(); err != nil {
+	log.Fatal(err)
+}
+
+var place Place
+q := qb.Select("place").Where(qb.Eq("id")).Query(session).BindMap(qb.M{"id": 1})
+if err := q.GetRelease(&place); err != nil {
+	log.Fatal(err)
+}
+```
+
+If a struct also contains fields tagged with tuple element names such as
+`db:"coordinate[0]"`, the field mapped to the whole tuple takes precedence when
+binding and scanning. Tuple-shaped structs use mapper-visible fields in
+declaration order; ignored fields do not count toward tuple arity. Byte arrays
+and slices remain scalar byte sequences, so use `[][]byte` for tuple blob
+elements.
+
 ## Generating table metadata with schemagen
 
 Installation

--- a/gocqlx.go
+++ b/gocqlx.go
@@ -38,6 +38,7 @@ func structOnlyError(t reflect.Type) error {
 // reflect helpers
 
 var (
+	marshalerInterface       = reflect.TypeOf((*gocql.Marshaler)(nil)).Elem()
 	unmarshallerInterface    = reflect.TypeOf((*gocql.Unmarshaler)(nil)).Elem()
 	udtUnmarshallerInterface = reflect.TypeOf((*gocql.UDTUnmarshaler)(nil)).Elem()
 	autoUDTInterface         = reflect.TypeOf((*UDT)(nil)).Elem()

--- a/iterx.go
+++ b/iterx.go
@@ -23,9 +23,8 @@ type Iterx struct {
 	*gocql.Iter
 	Mapper *reflectx.Mapper
 
-	// Cache memory for a rows during iteration in structScan.
-	fields     [][]int
-	values     []interface{}
+	// Cache memory for rows during iteration in structScan.
+	scanPlan   *structScanPlan
 	strict     bool
 	structOnly bool
 	applied    bool
@@ -89,6 +88,10 @@ func (iter *Iterx) scanAny(dest interface{}) bool {
 			iter.err = structOnlyError(base)
 			return false
 		}
+	}
+
+	if tuple, ok := iter.topLevelTuple(base); ok {
+		return iter.scanTuple(value, tuple)
 	}
 
 	if scannable && len(iter.Columns()) > 1 {
@@ -156,6 +159,8 @@ func (iter *Iterx) scanAll(dest interface{}) bool {
 		}
 	}
 
+	tuple, tupleContainer := iter.topLevelTuple(base)
+
 	// if it's a base type make sure it only has 1 column;  if not return an error
 	if scannable && len(iter.Columns()) > 1 {
 		iter.err = fmt.Errorf("expected 1 column in result while scanning scannable type %s but got %d", base.Kind(), len(iter.Columns()))
@@ -173,9 +178,12 @@ func (iter *Iterx) scanAll(dest interface{}) bool {
 		vp = reflect.New(base)
 
 		// scan into the struct field pointers
-		if !scannable {
+		switch {
+		case tupleContainer:
+			ok = iter.scanTuple(vp, tuple)
+		case !scannable:
 			ok = iter.structScan(vp)
-		} else {
+		default:
 			ok = iter.scan(vp)
 		}
 		if !ok {
@@ -231,12 +239,66 @@ func (iter *Iterx) scan(value reflect.Value) bool {
 	return iter.Iter.Scan(udtWrapValue(value, iter.Mapper, iter.strict))
 }
 
+func (iter *Iterx) topLevelTuple(t reflect.Type) (gocql.TupleTypeInfo, bool) {
+	if !isTupleScanContainerType(t) {
+		return gocql.TupleTypeInfo{}, false
+	}
+
+	columns := iter.Columns()
+	if len(columns) != 1 {
+		return gocql.TupleTypeInfo{}, false
+	}
+
+	tuple, ok := columns[0].TypeInfo.(gocql.TupleTypeInfo)
+	return tuple, ok
+}
+
+func (iter *Iterx) scanTuple(value reflect.Value, tuple gocql.TupleTypeInfo) bool {
+	// Stage tuple allocation and unmarshalling so an exhausted iterator leaves
+	// the caller's destination unchanged. Keep using Iter.Scan so callers may
+	// safely alternate Scan and StructScan, including across page boundaries.
+	staged := reflect.New(value.Elem().Type())
+	staged.Elem().Set(value.Elem())
+	if staged.Elem().Kind() == reflect.Ptr {
+		if err := clonePointerChain(staged.Elem()); err != nil {
+			iter.err = err
+			return false
+		}
+	}
+
+	values := make([]interface{}, len(tuple.Elems))
+	for i := range tuple.Elems {
+		elem, err := tupleElementAddr(staged, i, len(tuple.Elems))
+		if err != nil {
+			iter.err = err
+			return false
+		}
+		if elem.Elem().Kind() == reflect.Interface {
+			values[i] = tupleInterfaceScanner{value: elem.Elem()}
+			continue
+		}
+		values[i] = udtWrapValue(elem, iter.Mapper, iter.strict)
+	}
+
+	if !iter.Iter.Scan(values...) {
+		return false
+	}
+	value.Elem().Set(staged.Elem())
+	return true
+}
+
 // StructScan is like gocql.Iter.Scan, but scans a single row into a single
 // struct. Use this and iterate manually when the memory load of Select() might
 // be prohibitive. StructScan caches the reflect work of matching up column
 // positions to fields to avoid that overhead per scan, which means it is not
 // safe to run StructScan on the same Iterx instance with different struct
 // types.
+//
+// Tuple columns can scan into non-byte array, slice, or tuple-shaped struct
+// fields with the same mapped name. Tuple-shaped structs honor mapper-visible
+// fields, including embedded fields and db:"-" exclusions. Element fields named
+// with db tags, such as `db:"coordinates[0]"`, remain supported. When both forms
+// are present, the field mapped to the tuple column takes precedence.
 func (iter *Iterx) StructScan(dest interface{}) bool {
 	value := reflect.ValueOf(dest)
 
@@ -254,66 +316,255 @@ func (iter *Iterx) StructScan(dest interface{}) bool {
 
 const appliedColumn = "[applied]"
 
+type structScanPlan struct {
+	columns       []string
+	fields        [][]int
+	tupleIndexes  []int   // Element index for tuple containers; -1 for direct destinations.
+	tupleCounts   []int   // Tuple arity; zero for non-tuple columns.
+	freshPointers [][]int // Pointer fields replaced before each tuple row is scanned.
+	values        []interface{}
+	deferValues   bool // Destinations must stay staged until a row is scanned.
+}
+
+type tupleInterfaceScanner struct {
+	value reflect.Value
+}
+
+type tupleDiscardScanner struct{}
+
+func (tupleDiscardScanner) UnmarshalCQL(gocql.TypeInfo, []byte) error {
+	return nil
+}
+
+func (s tupleInterfaceScanner) UnmarshalCQL(info gocql.TypeInfo, data []byte) error {
+	if !s.value.CanSet() {
+		return fmt.Errorf("cannot set tuple interface element %s", s.value.Type())
+	}
+	if data == nil {
+		s.value.Set(reflect.Zero(s.value.Type()))
+		return nil
+	}
+
+	value, err := info.NewWithError()
+	if err != nil {
+		return err
+	}
+	if err := gocql.Unmarshal(info, data, value); err != nil {
+		return err
+	}
+
+	elem := reflect.ValueOf(value).Elem()
+	if !elem.Type().AssignableTo(s.value.Type()) {
+		return fmt.Errorf("cannot unmarshal %s into %s", info, s.value.Type())
+	}
+	s.value.Set(elem)
+	return nil
+}
+
 func (iter *Iterx) structScan(value reflect.Value) bool {
 	if value.Kind() != reflect.Ptr {
 		panic("value must be a pointer")
 	}
 
-	if iter.fields == nil {
-		columns := columnNames(iter.Columns())
-		cas := len(columns) > 0 && columns[0] == appliedColumn
+	if iter.scanPlan == nil {
+		plan, err := iter.buildStructScanPlan(value.Type(), iter.Columns())
+		if err != nil {
+			iter.err = err
+			return false
+		}
+		cas := len(plan.columns) > 0 && plan.columns[0] == appliedColumn
 
-		iter.fields = iter.Mapper.TraversalsByName(value.Type(), columns)
 		// if we are strict and it's not CAS query and are missing fields, return an error
 		if iter.strict && !cas {
-			if f, err := missingFields(iter.fields); err != nil {
-				iter.err = fmt.Errorf("missing destination name %q in %s", columns[f], reflect.Indirect(value).Type())
+			if f, err := missingFields(plan.fields); err != nil {
+				iter.err = fmt.Errorf("missing destination name %q in %s", plan.columns[f], reflect.Indirect(value).Type())
 				return false
 			}
 		}
-		iter.values = make([]interface{}, len(columns))
 		if cas {
-			iter.values[0] = &iter.applied
+			plan.values[0] = &iter.applied
 		}
+		iter.scanPlan = &plan
 	}
 
-	if err := iter.fieldsByTraversal(value, iter.fields, iter.values); err != nil {
+	scanValue := value
+	if iter.scanPlan.deferValues {
+		// Tuple plans are prepared against a staged copy. Commit only after Scan
+		// succeeds, preserving the destination when no row is available.
+		scanValue = reflect.New(reflect.Indirect(value).Type())
+		scanValue.Elem().Set(reflect.Indirect(value))
+	}
+	if err := iter.fieldsByTraversal(scanValue, iter.scanPlan); err != nil {
 		iter.err = err
 		return false
 	}
 
 	// scan into the struct field pointers and append to our results
-	return iter.Iter.Scan(iter.values...)
+	if iter.scanPlan.deferValues {
+		if !iter.Iter.Scan(iter.scanPlan.values...) {
+			return false
+		}
+		reflect.Indirect(value).Set(scanValue.Elem())
+		return true
+	}
+	return iter.Iter.Scan(iter.scanPlan.values...)
 }
 
-// fieldsByName fills a values interface with fields from the passed value based
-// on the traversals in int.
+func (iter *Iterx) buildStructScanPlan(t reflect.Type, columnInfo []gocql.ColumnInfo) (structScanPlan, error) {
+	columns := make([]string, len(columnInfo))
+	ordinary := true
+	for i, column := range columnInfo {
+		columns[i] = column.Name
+		if _, ok := column.TypeInfo.(gocql.TupleTypeInfo); ok {
+			ordinary = false
+		}
+	}
+	if ordinary {
+		tupleIndexes := make([]int, len(columns))
+		for i := range tupleIndexes {
+			tupleIndexes[i] = -1
+		}
+		return structScanPlan{
+			columns:      columns,
+			fields:       iter.Mapper.TraversalsByName(t, columns),
+			tupleIndexes: tupleIndexes,
+			tupleCounts:  make([]int, len(columns)),
+			values:       make([]interface{}, len(columns)),
+		}, nil
+	}
+
+	// Tuple destinations may require allocating slices, maps, or pointer fields.
+	// Stage every mixed plan so an exhausted iterator leaves the destination
+	// unchanged.
+	plan := structScanPlan{deferValues: true}
+	appendFreshPointers := func(traversal []int) {
+		for _, pointer := range pointerTraversals(t, traversal) {
+			found := false
+			for _, existing := range plan.freshPointers {
+				if equalTraversal(existing, pointer) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				plan.freshPointers = append(plan.freshPointers, pointer)
+			}
+		}
+	}
+	appendDestination := func(name string, traversal []int, tupleIndex, tupleCount int, discard interface{}) {
+		plan.columns = append(plan.columns, name)
+		if traversal == nil {
+			traversal = []int{}
+		}
+		plan.fields = append(plan.fields, traversal)
+		plan.tupleIndexes = append(plan.tupleIndexes, tupleIndex)
+		plan.tupleCounts = append(plan.tupleCounts, tupleCount)
+		plan.values = append(plan.values, discard)
+	}
+
+	for _, column := range columnInfo {
+		tuple, ok := column.TypeInfo.(gocql.TupleTypeInfo)
+		if !ok {
+			appendDestination(column.Name, traversalByName(iter.Mapper, t, column.Name), -1, 0, nil)
+			continue
+		}
+
+		traversal := traversalByName(iter.Mapper, t, column.Name)
+		if len(traversal) != 0 {
+			fieldType := fieldTypeByTraversal(t, traversal)
+			switch {
+			case isTupleScanContainerType(fieldType):
+				appendFreshPointers(traversal)
+				baseType := derefTupleType(fieldType)
+				if baseType.Kind() == reflect.Array && baseType.Len() != len(tuple.Elems) {
+					return structScanPlan{}, fmt.Errorf(
+						"cannot scan tuple column %q into %s: array length %d does not match tuple element count %d",
+						column.Name, fieldType, baseType.Len(), len(tuple.Elems),
+					)
+				}
+				for i := range tuple.Elems {
+					appendDestination(gocql.TupleColumnName(column.Name, i), traversal, i, len(tuple.Elems), nil)
+				}
+				continue
+			case isTupleStructType(fieldType, unmarshallerInterface):
+				elemTraversals := tupleStructTraversals(iter.Mapper, fieldType)
+				if len(elemTraversals) != len(tuple.Elems) {
+					return structScanPlan{}, fmt.Errorf(
+						"cannot scan tuple column %q into %s: struct has %d mapped fields, expected %d tuple elements",
+						column.Name, fieldType, len(elemTraversals), len(tuple.Elems),
+					)
+				}
+				for i, fieldTraversal := range elemTraversals {
+					elemTraversal := append(append([]int(nil), traversal...), fieldTraversal...)
+					appendFreshPointers(elemTraversal)
+					appendDestination(gocql.TupleColumnName(column.Name, i), elemTraversal, -1, len(tuple.Elems), nil)
+				}
+				continue
+			}
+			return structScanPlan{}, fmt.Errorf(
+				"cannot scan tuple column %q into %v; expected a non-byte array, slice, or struct with %d mapped fields",
+				column.Name, fieldType, len(tuple.Elems),
+			)
+		}
+
+		for i := range tuple.Elems {
+			name := gocql.TupleColumnName(column.Name, i)
+			traversal := traversalByName(iter.Mapper, t, name)
+			var discard interface{}
+			if len(traversal) == 0 {
+				discard = tupleDiscardScanner{}
+			} else {
+				appendFreshPointers(traversal)
+			}
+			appendDestination(name, traversal, -1, len(tuple.Elems), discard)
+		}
+	}
+
+	return plan, nil
+}
+
+// fieldsByTraversal fills plan.values with addressable destinations from the
+// passed value based on the traversals in plan.fields.
 // We write this instead of using FieldsByName to save allocations and map
 // lookups when iterating over many rows.
-// Empty traversals will get an interface pointer.
-func (iter *Iterx) fieldsByTraversal(value reflect.Value, traversals [][]int, values []interface{}) error {
+// Columns with an empty traversal keep the destination assigned during planning.
+func (iter *Iterx) fieldsByTraversal(value reflect.Value, plan *structScanPlan) error {
 	value = reflect.Indirect(value)
 	if value.Kind() != reflect.Struct {
 		return fmt.Errorf("expected a struct but got %s", value.Type())
 	}
+	for _, traversal := range plan.freshPointers {
+		if err := freshPointerByTraversal(value, traversal); err != nil {
+			return err
+		}
+	}
 
-	for i, traversal := range traversals {
+	for i, traversal := range plan.fields {
 		if len(traversal) == 0 {
 			continue
 		}
-		f := reflectx.FieldByIndexes(value, traversal).Addr()
-		values[i] = udtWrapValue(f, iter.Mapper, iter.strict)
+		f := reflectx.FieldByIndexes(value, traversal)
+		if plan.tupleIndexes[i] >= 0 {
+			elem, err := tupleElementAddr(f, plan.tupleIndexes[i], plan.tupleCounts[i])
+			if err != nil {
+				return err
+			}
+			if elem.Elem().Kind() == reflect.Interface {
+				plan.values[i] = tupleInterfaceScanner{value: elem.Elem()}
+				continue
+			}
+			plan.values[i] = udtWrapValue(elem, iter.Mapper, iter.strict)
+			continue
+		}
+		if plan.tupleCounts[i] > 0 && f.Kind() == reflect.Interface {
+			plan.values[i] = tupleInterfaceScanner{value: f}
+			continue
+		}
+		f = f.Addr()
+		plan.values[i] = udtWrapValue(f, iter.Mapper, iter.strict)
 	}
 
 	return nil
-}
-
-func columnNames(ci []gocql.ColumnInfo) []string {
-	r := make([]string, len(ci))
-	for i, column := range ci {
-		r[i] = column.Name
-	}
-	return r
 }
 
 // Scan consumes the next row of the iterator and copies the columns of the

--- a/iterx_test.go
+++ b/iterx_test.go
@@ -59,6 +59,232 @@ func diff(t *testing.T, expected, got interface{}) {
 
 var diffOpts = cmpopts.IgnoreUnexported(big.Int{}, inf.Dec{})
 
+func TestIterxTupleArraySlice(t *testing.T) {
+	session := gocqlxtest.CreateSession(t)
+	t.Cleanup(func() {
+		session.Close()
+	})
+
+	if err := session.ExecStmt(`CREATE TABLE gocqlx_test.tuple_table (
+			k int PRIMARY KEY,
+			c frozen<tuple<int, int>>
+		)`); err != nil {
+		t.Fatal("create table:", err)
+	}
+
+	insert := qb.Insert("gocqlx_test.tuple_table").Columns("k").TupleColumn("c", 2).Query(session)
+	if err := insert.BindMap(qb.M{
+		"k": 1,
+		"c": [2]int{12, 34},
+	}).Exec(); err != nil {
+		t.Fatal("insert array tuple:", err)
+	}
+
+	type tupleRow struct {
+		K int
+		C []int
+	}
+
+	if err := insert.BindStruct(tupleRow{
+		K: 2,
+		C: []int{56, 78},
+	}).ExecRelease(); err != nil {
+		t.Fatal("insert slice tuple:", err)
+	}
+	insert = qb.Insert("gocqlx_test.tuple_table").Columns("k").TupleColumn("c", 2).Query(session)
+	if err := insert.BindMap(qb.M{
+		"k": 3,
+		"c": []interface{}{nil, 90},
+	}).ExecRelease(); err != nil {
+		t.Fatal("insert tuple with null element:", err)
+	}
+
+	var arrayRow struct {
+		K int
+		C [2]int
+	}
+	if err := qb.Select("gocqlx_test.tuple_table").
+		Where(qb.EqLit("k", "1")).
+		Query(session).
+		Get(&arrayRow); err != nil {
+		t.Fatal("get array tuple:", err)
+	}
+	diff(t, struct {
+		K int
+		C [2]int
+	}{K: 1, C: [2]int{12, 34}}, arrayRow)
+
+	var sliceRow tupleRow
+	if err := qb.Select("gocqlx_test.tuple_table").
+		Where(qb.EqLit("k", "2")).
+		Query(session).
+		Get(&sliceRow); err != nil {
+		t.Fatal("get slice tuple:", err)
+	}
+	diff(t, tupleRow{K: 2, C: []int{56, 78}}, sliceRow)
+
+	t.Run("no row preserves tuple slice", func(t *testing.T) {
+		dest := tupleRow{K: 99, C: []int{9, 10}}
+		err := qb.Select("gocqlx_test.tuple_table").
+			Where(qb.EqLit("k", "999")).
+			Query(session).
+			Get(&dest)
+		if err != gocql.ErrNotFound {
+			t.Fatalf("Get() error=%v, want %v", err, gocql.ErrNotFound)
+		}
+		diff(t, tupleRow{K: 99, C: []int{9, 10}}, dest)
+	})
+
+	t.Run("exhausted struct scan preserves tuple slice", func(t *testing.T) {
+		iter := qb.Select("gocqlx_test.tuple_table").
+			Where(qb.EqLit("k", "1")).
+			Query(session).
+			Iter()
+		var dest tupleRow
+		if !iter.StructScan(&dest) {
+			t.Fatal("first StructScan failed:", iter.Close())
+		}
+		if iter.StructScan(&dest) {
+			t.Fatal("unexpected second row")
+		}
+		if err := iter.Close(); err != nil {
+			t.Fatal("close iterator:", err)
+		}
+		diff(t, tupleRow{K: 1, C: []int{12, 34}}, dest)
+	})
+
+	var structRow struct {
+		K int
+		C struct {
+			Field1 int
+			Field2 int
+		}
+	}
+	if err := qb.Select("gocqlx_test.tuple_table").
+		Where(qb.EqLit("k", "1")).
+		Query(session).
+		Get(&structRow); err != nil {
+		t.Fatal("get struct tuple:", err)
+	}
+	diff(t, struct {
+		K int
+		C struct {
+			Field1 int
+			Field2 int
+		}
+	}{K: 1, C: struct {
+		Field1 int
+		Field2 int
+	}{Field1: 12, Field2: 34}}, structRow)
+
+	var taggedRow struct {
+		K  int
+		C0 int `db:"c[0]"`
+		C1 int `db:"c[1]"`
+	}
+	if err := qb.Select("gocqlx_test.tuple_table").
+		Where(qb.EqLit("k", "1")).
+		Query(session).
+		Get(&taggedRow); err != nil {
+		t.Fatal("get tagged tuple elements:", err)
+	}
+	diff(t, struct {
+		K  int
+		C0 int `db:"c[0]"`
+		C1 int `db:"c[1]"`
+	}{K: 1, C0: 12, C1: 34}, taggedRow)
+
+	var taggedInterfaceRow struct {
+		K  int
+		C0 interface{} `db:"c[0]"`
+		C1 interface{} `db:"c[1]"`
+	}
+	if err := qb.Select("gocqlx_test.tuple_table").
+		Where(qb.EqLit("k", "1")).
+		Query(session).
+		Get(&taggedInterfaceRow); err != nil {
+		t.Fatal("get tagged interface tuple elements:", err)
+	}
+	diff(t, struct {
+		K  int
+		C0 interface{} `db:"c[0]"`
+		C1 interface{} `db:"c[1]"`
+	}{K: 1, C0: 12, C1: 34}, taggedInterfaceRow)
+
+	var interfaceRow struct {
+		K int
+		C []interface{}
+	}
+	if err := qb.Select("gocqlx_test.tuple_table").
+		Where(qb.EqLit("k", "3")).
+		Query(session).
+		Get(&interfaceRow); err != nil {
+		t.Fatal("get nullable interface tuple:", err)
+	}
+	diff(t, struct {
+		K int
+		C []interface{}
+	}{K: 3, C: []interface{}{nil, 90}}, interfaceRow)
+
+	var topArray [2]int
+	if err := qb.Select("gocqlx_test.tuple_table").
+		Columns("c").
+		Where(qb.EqLit("k", "1")).
+		Query(session).
+		Get(&topArray); err != nil {
+		t.Fatal("get top-level array tuple:", err)
+	}
+	diff(t, [2]int{12, 34}, topArray)
+
+	var topSlice []int
+	if err := qb.Select("gocqlx_test.tuple_table").
+		Columns("c").
+		Where(qb.EqLit("k", "2")).
+		Query(session).
+		Get(&topSlice); err != nil {
+		t.Fatal("get top-level slice tuple:", err)
+	}
+	diff(t, []int{56, 78}, topSlice)
+
+	var topArrays [][2]int
+	if err := qb.Select("gocqlx_test.tuple_table").
+		Columns("c").
+		Where(qb.EqLit("k", "1")).
+		Query(session).
+		Select(&topArrays); err != nil {
+		t.Fatal("select top-level array tuples:", err)
+	}
+	diff(t, [][2]int{{12, 34}}, topArrays)
+
+	var topSlices [][]int
+	if err := qb.Select("gocqlx_test.tuple_table").
+		Columns("c").
+		Where(qb.EqLit("k", "2")).
+		Query(session).
+		Select(&topSlices); err != nil {
+		t.Fatal("select top-level slice tuples:", err)
+	}
+	diff(t, [][]int{{56, 78}}, topSlices)
+
+	if err := qb.Update("gocqlx_test.tuple_table").
+		SetTuple("c", 2).
+		Where(qb.Eq("k")).
+		Query(session).
+		BindMap(qb.M{"k": 2, "c": []int{91, 92}}).
+		ExecRelease(); err != nil {
+		t.Fatal("update tuple:", err)
+	}
+
+	sliceRow = tupleRow{}
+	if err := qb.Select("gocqlx_test.tuple_table").
+		Where(qb.EqLit("k", "2")).
+		Query(session).
+		Get(&sliceRow); err != nil {
+		t.Fatal("get updated tuple:", err)
+	}
+	diff(t, tupleRow{K: 2, C: []int{91, 92}}, sliceRow)
+}
+
 func TestIterxUDT(t *testing.T) {
 	session := gocqlxtest.CreateSession(t)
 	t.Cleanup(func() {

--- a/qb/insert.go
+++ b/qb/insert.go
@@ -142,6 +142,7 @@ func (b *InsertBuilder) FuncColumn(column string, fn *Func) *InsertBuilder {
 }
 
 // TupleColumn adds an insert column for a tuple value to the query.
+// It generates bind names in the form "column[0]", "column[1]", and so on.
 func (b *InsertBuilder) TupleColumn(column string, count int) *InsertBuilder {
 	b.columns = append(b.columns, initializer{
 		column: column,

--- a/qb/update.go
+++ b/qb/update.go
@@ -169,6 +169,7 @@ func (b *UpdateBuilder) SetFunc(column string, fn *Func) *UpdateBuilder {
 }
 
 // SetTuple adds a SET clause for a tuple to the query.
+// It generates bind names in the form "column[0]", "column[1]", and so on.
 func (b *UpdateBuilder) SetTuple(column string, count int) *UpdateBuilder {
 	b.assignments = append(b.assignments, assignment{
 		column: column,

--- a/qb/value.go
+++ b/qb/value.go
@@ -6,7 +6,8 @@ package qb
 
 import (
 	"bytes"
-	"strconv"
+
+	"github.com/gocql/gocql"
 )
 
 // value is a CQL value expression for use in an initializer, assignment,
@@ -25,7 +26,7 @@ func (p param) writeCql(cql *bytes.Buffer) (names []string) {
 	return []string{string(p)}
 }
 
-// param is a named CQL tuple '?' parameter.
+// tupleParam is a named CQL tuple '?' parameter.
 type tupleParam struct {
 	param param
 	count int
@@ -37,11 +38,11 @@ func (t tupleParam) writeCql(cql *bytes.Buffer) (names []string) {
 	for i := 0; i < t.count-1; i++ {
 		cql.WriteByte('?')
 		cql.WriteByte(',')
-		names = append(names, baseName+"["+strconv.Itoa(i)+"]")
+		names = append(names, gocql.TupleColumnName(baseName, i))
 	}
 	cql.WriteByte('?')
 	cql.WriteByte(')')
-	names = append(names, baseName+"["+strconv.Itoa(t.count-1)+"]")
+	names = append(names, gocql.TupleColumnName(baseName, t.count-1))
 
 	return
 }

--- a/queryx.go
+++ b/queryx.go
@@ -91,9 +91,12 @@ func allowedBindRune(b byte) bool {
 
 // Queryx is a wrapper around gocql.Query which adds struct binding capabilities.
 type Queryx struct {
-	err    error
-	tr     Transformer
-	Mapper *reflectx.Mapper
+	err           error
+	tr            Transformer
+	statement     string
+	tupleElements []tupleBindElement
+	tupleNames    []string
+	Mapper        *reflectx.Mapper
 	*gocql.Query
 	Names  []string
 	strict bool
@@ -103,12 +106,19 @@ type Queryx struct {
 //
 // Deprecated: Use gocqlx.Session.Query API instead.
 func Query(q *gocql.Query, names []string) *Queryx {
+	var statement string
+	if q != nil {
+		statement = q.Statement()
+	}
 	return &Queryx{
-		Query:  q,
-		Names:  names,
-		Mapper: DefaultMapper,
-		tr:     DefaultBindTransformer,
-		strict: DefaultStrict,
+		Query:         q,
+		Names:         names,
+		Mapper:        DefaultMapper,
+		tr:            DefaultBindTransformer,
+		strict:        DefaultStrict,
+		statement:     statement,
+		tupleElements: tupleBindElements(statement, names),
+		tupleNames:    append([]string(nil), names...),
 	}
 }
 
@@ -121,6 +131,12 @@ func (q *Queryx) WithBindTransformer(tr Transformer) *Queryx {
 
 // BindStruct binds query named parameters to values from arg using mapper. If
 // value cannot be found error is reported.
+//
+// Tuple element parameters, such as "coordinates[0]" and "coordinates[1]", can
+// be bound from a non-byte array, slice, or tuple-shaped struct field named
+// "coordinates". Container length or mapped struct field count must match the
+// tuple element count. A same-name tuple field takes precedence over fields
+// tagged with individual element names.
 func (q *Queryx) BindStruct(arg interface{}) *Queryx {
 	arglist, err := q.bindStructArgs(arg, nil)
 	if err != nil {
@@ -136,6 +152,11 @@ func (q *Queryx) BindStruct(arg interface{}) *Queryx {
 // BindStructMap binds query named parameters to values from arg0 and arg1
 // using a mapper. If value cannot be found in arg0 it's looked up in arg1
 // before reporting an error.
+//
+// Tuple element parameters follow BindStruct and BindMap rules. For example,
+// "coordinates[0]" and "coordinates[1]" can be bound from a non-byte array,
+// slice, or tuple-shaped struct field in arg0, or from such a value stored under
+// "coordinates" in arg1.
 func (q *Queryx) BindStructMap(arg0 interface{}, arg1 map[string]interface{}) *Queryx {
 	arglist, err := q.bindStructArgs(arg0, arg1)
 	if err != nil {
@@ -172,6 +193,7 @@ func (q *Queryx) SetHostID(hostID string) *Queryx {
 
 func (q *Queryx) bindStructArgs(arg0 interface{}, arg1 map[string]interface{}) ([]interface{}, error) {
 	arglist := make([]interface{}, 0, len(q.Names))
+	tupleElements := q.cachedTupleBindElements()
 
 	// grab the indirected value of arg
 	v := reflect.ValueOf(arg0)
@@ -179,21 +201,52 @@ func (q *Queryx) bindStructArgs(arg0 interface{}, arg1 map[string]interface{}) (
 		v = v.Elem()
 	}
 
-	err := q.Mapper.TraversalsByNameFunc(v.Type(), q.Names, func(i int, t []int) error {
-		if len(t) != 0 {
-			val := reflectx.FieldByIndexesReadOnly(v, t)
-			arglist = append(arglist, val.Interface())
-		} else {
-			val, ok := arg1[q.Names[i]]
-			if !ok {
-				return fmt.Errorf("could not find name %q in %#v and %#v", q.Names[i], arg0, arg1)
-			}
-			arglist = append(arglist, val)
-		}
+	err := q.Mapper.TraversalsByNameFunc(v.Type(), q.Names, func(i int, directTraversal []int) error {
+		name := q.Names[i]
+		tuple := tupleElements[i]
+		var val interface{}
 
-		if q.tr != nil {
-			arglist[i] = q.tr(q.Names[i], arglist[i])
+		switch {
+		case tuple.count != 0:
+			element, found, tupleErr := tupleElementByName(q.Mapper, v, name, tuple)
+			switch {
+			case tupleErr == nil && found:
+				val = element.Interface()
+			case tupleErr != nil:
+				// An explicit BindStructMap element remains a valid fallback when
+				// the struct has a same-name field that is not a tuple container.
+				var ok bool
+				if val, ok = arg1[name]; !ok {
+					return tupleErr
+				}
+			case len(directTraversal) != 0:
+				val = reflectx.FieldByIndexesReadOnly(v, directTraversal).Interface()
+			default:
+				var ok bool
+				val, ok = arg1[name]
+				if !ok {
+					var err error
+					val, ok, err = tupleElementFromMap(q.Mapper, arg1, name, tuple)
+					if err != nil {
+						return err
+					}
+					if !ok {
+						return fmt.Errorf("could not find name %q in %#v and %#v", name, arg0, arg1)
+					}
+				}
+			}
+		case len(directTraversal) != 0:
+			val = reflectx.FieldByIndexesReadOnly(v, directTraversal).Interface()
+		default:
+			var ok bool
+			val, ok = arg1[name]
+			if !ok {
+				return fmt.Errorf("could not find name %q in %#v and %#v", name, arg0, arg1)
+			}
 		}
+		arglist = append(arglist, val)
+
+		arglist[i] = q.transformBindValue(name, arglist[i], tuple.count != 0)
 
 		return nil
 	})
@@ -202,6 +255,11 @@ func (q *Queryx) bindStructArgs(arg0 interface{}, arg1 map[string]interface{}) (
 }
 
 // BindMap binds query named parameters using map.
+//
+// Tuple element parameters, such as "coordinates[0]" and "coordinates[1]", can
+// be bound from a non-byte array, slice, or tuple-shaped struct value stored
+// under "coordinates". Container length or mapped struct field count must match
+// the tuple element count.
 func (q *Queryx) BindMap(arg map[string]interface{}) *Queryx {
 	arglist, err := q.bindMapArgs(arg)
 	if err != nil {
@@ -216,19 +274,57 @@ func (q *Queryx) BindMap(arg map[string]interface{}) *Queryx {
 
 func (q *Queryx) bindMapArgs(arg map[string]interface{}) ([]interface{}, error) {
 	arglist := make([]interface{}, 0, len(q.Names))
+	tupleElements := q.cachedTupleBindElements()
 
-	for _, name := range q.Names {
+	for i, name := range q.Names {
 		val, ok := arg[name]
 		if !ok {
-			return arglist, fmt.Errorf("could not find name %q in %#v", name, arg)
+			var err error
+			val, ok, err = tupleElementFromMap(q.Mapper, arg, name, tupleElements[i])
+			if err != nil {
+				return arglist, err
+			}
+			if !ok {
+				return arglist, fmt.Errorf("could not find name %q in %#v", name, arg)
+			}
 		}
 
-		if q.tr != nil {
-			val = q.tr(name, val)
-		}
+		val = q.transformBindValue(name, val, tupleElements[i].count != 0)
 		arglist = append(arglist, val)
 	}
 	return arglist, nil
+}
+
+func (q *Queryx) transformBindValue(name string, value interface{}, tupleElement bool) interface{} {
+	if q.tr == nil {
+		return value
+	}
+
+	transformed := q.tr(name, value)
+	if tupleElement && reflect.TypeOf(transformed) == reflect.TypeOf(gocql.UnsetValue) {
+		return value
+	}
+	return transformed
+}
+
+func (q *Queryx) cachedTupleBindElements() []tupleBindElement {
+	if q.tupleElements == nil || !equalNames(q.tupleNames, q.Names) {
+		q.tupleElements = tupleBindElements(q.statement, q.Names)
+		q.tupleNames = append(q.tupleNames[:0], q.Names...)
+	}
+	return q.tupleElements
+}
+
+func equalNames(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // Bind sets query arguments of query. This can also be used to rebind new query arguments

--- a/queryx_test.go
+++ b/queryx_test.go
@@ -5,7 +5,10 @@
 package gocqlx
 
 import (
+	"math"
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/gocql/gocql"
@@ -162,6 +165,208 @@ func TestQueryxBindStruct(t *testing.T) {
 			t.Fatal("unexpected error")
 		}
 	})
+
+	t.Run("tuple array", func(t *testing.T) {
+		v := &struct {
+			Coordinates [2]int
+		}{
+			Coordinates: [2]int{12, 34},
+		}
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		args, err := Query(nil, names).bindStructArgs(v, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(args, []interface{}{12, 34}); diff != "" {
+			t.Error("args mismatch", diff)
+		}
+	})
+
+	t.Run("tuple slice", func(t *testing.T) {
+		v := &struct {
+			Coordinates []int
+		}{
+			Coordinates: []int{56, 78},
+		}
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		args, err := Query(nil, names).bindStructArgs(v, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(args, []interface{}{56, 78}); diff != "" {
+			t.Error("args mismatch", diff)
+		}
+	})
+
+	t.Run("tuple zero values are not unset", func(t *testing.T) {
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		args, err := Query(nil, names).
+			WithBindTransformer(UnsetEmptyTransformer).
+			bindStructArgs(&struct{ Coordinates [2]float64 }{Coordinates: [2]float64{0, 19.94}}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(args, []interface{}{float64(0), 19.94}); diff != "" {
+			t.Error("args mismatch", diff)
+		}
+	})
+
+	t.Run("tuple array arity mismatch", func(t *testing.T) {
+		v := &struct {
+			Coordinates [3]int
+		}{
+			Coordinates: [3]int{12, 34, 56},
+		}
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		_, err := Query(nil, names).bindStructArgs(v, nil)
+		if err == nil {
+			t.Fatal("unexpected nil error")
+		}
+		if !strings.Contains(err.Error(), "array length 3 does not match tuple element count 2") {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("tuple slice arity mismatch", func(t *testing.T) {
+		v := &struct {
+			Coordinates []int
+		}{
+			Coordinates: []int{56, 78, 90},
+		}
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		_, err := Query(nil, names).bindStructArgs(v, nil)
+		if err == nil {
+			t.Fatal("unexpected nil error")
+		}
+		if !strings.Contains(err.Error(), "slice length 3 does not match tuple element count 2") {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("tuple byte array", func(t *testing.T) {
+		v := &struct {
+			Coordinates [2]byte
+		}{
+			Coordinates: [2]byte{12, 34},
+		}
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		_, err := Query(nil, names).bindStructArgs(v, nil)
+		if err == nil || !strings.Contains(err.Error(), "expected a non-byte array") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("unsupported tuple field does not fall back to map", func(t *testing.T) {
+		v := &struct {
+			Coordinates int
+		}{
+			Coordinates: 12,
+		}
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		_, err := Query(nil, names).bindStructArgs(v, map[string]interface{}{
+			"coordinates": []int{34, 56},
+		})
+		if err == nil || !strings.Contains(err.Error(), `expected a non-byte array, slice, or struct`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("tuple container takes precedence over element fields", func(t *testing.T) {
+		v := &struct {
+			Coordinates [2]int
+			C0          int `db:"coordinates[0]"`
+			C1          int `db:"coordinates[1]"`
+		}{
+			Coordinates: [2]int{12, 34},
+			C0:          56,
+			C1:          78,
+		}
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		args, err := Query(nil, names).bindStructArgs(v, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(args, []interface{}{12, 34}); diff != "" {
+			t.Error("args mismatch", diff)
+		}
+	})
+
+	t.Run("explicit map element overrides unsupported tuple field", func(t *testing.T) {
+		v := &struct{ Coordinates string }{Coordinates: "not a tuple"}
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		args, err := Query(nil, names).bindStructArgs(v, map[string]interface{}{
+			"coordinates[0]": 12,
+			"coordinates[1]": 34,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(args, []interface{}{12, 34}); diff != "" {
+			t.Error("args mismatch", diff)
+		}
+	})
+
+	t.Run("tuple-shaped struct", func(t *testing.T) {
+		type embedded struct {
+			First int
+		}
+		type coordinates struct {
+			embedded
+			Ignored string `db:"-"`
+			Second  int
+		}
+		v := &struct{ Coordinates coordinates }{
+			Coordinates: coordinates{embedded: embedded{First: 12}, Ignored: "ignored", Second: 34},
+		}
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		args, err := Query(nil, names).bindStructArgs(v, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(args, []interface{}{12, 34}); diff != "" {
+			t.Error("args mismatch", diff)
+		}
+	})
+
+	t.Run("collection element name is not inferred as tuple", func(t *testing.T) {
+		q := &Queryx{
+			Names:     []string{"items[0]"},
+			Mapper:    DefaultMapper,
+			statement: "UPDATE tbl SET items[0]=? ",
+		}
+		_, err := q.bindStructArgs(&struct{ Items []int }{Items: []int{7}}, nil)
+		if err == nil || !strings.Contains(err.Error(), `could not find name "items[0]"`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("tuple index overflow", func(t *testing.T) {
+		v := &struct {
+			Coordinates []int
+		}{
+			Coordinates: []int{},
+		}
+		name := "coordinates[" + strconv.Itoa(math.MaxInt) + "]"
+		_, err := Query(nil, []string{name}).bindStructArgs(v, nil)
+		if err == nil || !strings.Contains(err.Error(), name) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("tuple container behind nil embedded pointer", func(t *testing.T) {
+		type tupleFields struct {
+			Coordinates []int
+		}
+		v := &struct {
+			*tupleFields
+		}{}
+		_, err := Query(nil, []string{"coordinates[0]"}).bindStructArgs(v, nil)
+		if err == nil || !strings.Contains(err.Error(), "nil pointer in field traversal") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestQueryxBindMap(t *testing.T) {
@@ -210,6 +415,205 @@ func TestQueryxBindMap(t *testing.T) {
 			t.Fatal("unexpected error")
 		}
 	})
+
+	t.Run("tuple array", func(t *testing.T) {
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		args, err := Query(nil, names).bindMapArgs(map[string]interface{}{
+			"coordinates": [2]int{12, 34},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(args, []interface{}{12, 34}); diff != "" {
+			t.Error("args mismatch", diff)
+		}
+	})
+
+	t.Run("tuple slice", func(t *testing.T) {
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		args, err := Query(nil, names).bindMapArgs(map[string]interface{}{
+			"coordinates": []int{56, 78},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(args, []interface{}{56, 78}); diff != "" {
+			t.Error("args mismatch", diff)
+		}
+	})
+
+	t.Run("tuple nil values are not unset", func(t *testing.T) {
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		args, err := Query(nil, names).
+			WithBindTransformer(UnsetEmptyTransformer).
+			bindMapArgs(map[string]interface{}{
+				"coordinates": []interface{}{nil, 90},
+			})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(args, []interface{}{nil, 90}); diff != "" {
+			t.Error("args mismatch", diff)
+		}
+	})
+
+	t.Run("tuple array arity mismatch", func(t *testing.T) {
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		_, err := Query(nil, names).bindMapArgs(map[string]interface{}{
+			"coordinates": [3]int{12, 34, 56},
+		})
+		if err == nil {
+			t.Fatal("unexpected nil error")
+		}
+		if !strings.Contains(err.Error(), "array length 3 does not match tuple element count 2") {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("tuple slice arity mismatch", func(t *testing.T) {
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		_, err := Query(nil, names).bindMapArgs(map[string]interface{}{
+			"coordinates": []int{56, 78, 90},
+		})
+		if err == nil {
+			t.Fatal("unexpected nil error")
+		}
+		if !strings.Contains(err.Error(), "slice length 3 does not match tuple element count 2") {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("tuple nil slice", func(t *testing.T) {
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		_, err := Query(nil, names).bindMapArgs(map[string]interface{}{
+			"coordinates": []int(nil),
+		})
+		if err == nil {
+			t.Fatal("unexpected nil error")
+		}
+		if !strings.Contains(err.Error(), "nil slice does not match tuple element count 2") {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("tuple byte slice", func(t *testing.T) {
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		_, err := Query(nil, names).bindMapArgs(map[string]interface{}{
+			"coordinates": []byte("ab"),
+		})
+		if err == nil || !strings.Contains(err.Error(), "expected a non-byte array") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("collection element exact key", func(t *testing.T) {
+		q := &Queryx{
+			Names:     []string{"items[0]"},
+			Mapper:    DefaultMapper,
+			statement: "UPDATE tbl SET items[0]=? ",
+		}
+		args, err := q.bindMapArgs(map[string]interface{}{
+			"items":    []int{7},
+			"items[0]": 42,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(args, []interface{}{42}); diff != "" {
+			t.Error("args mismatch", diff)
+		}
+	})
+
+	t.Run("tuple blob slice", func(t *testing.T) {
+		names := []string{"coordinates[0]", "coordinates[1]"}
+		args, err := Query(nil, names).bindMapArgs(map[string]interface{}{
+			"coordinates": [][]byte{{1, 2}, {3, 4}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(args, []interface{}{[]byte{1, 2}, []byte{3, 4}}); diff != "" {
+			t.Error("args mismatch", diff)
+		}
+	})
+
+	t.Run("tuple index overflow", func(t *testing.T) {
+		name := "coordinates[" + strconv.Itoa(math.MaxInt) + "]"
+		_, err := Query(nil, []string{name}).bindMapArgs(map[string]interface{}{
+			"coordinates": []int{},
+		})
+		if err == nil || !strings.Contains(err.Error(), name) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestQueryxCachesTupleBindElements(t *testing.T) {
+	q := &Queryx{
+		Names:     []string{"coordinates[0]", "coordinates[1]"},
+		Mapper:    DefaultMapper,
+		statement: "UPDATE tbl SET coordinates=(?,?) ",
+	}
+
+	first := q.cachedTupleBindElements()
+	if len(first) != 2 || first[0].count != 2 || first[1].count != 2 {
+		t.Fatalf("unexpected tuple metadata: %#v", first)
+	}
+
+	q.statement = "UPDATE tbl SET coordinates=? "
+	second := q.cachedTupleBindElements()
+	if &first[0] != &second[0] {
+		t.Fatal("tuple metadata was recomputed")
+	}
+
+	q.statement = "UPDATE tbl SET coordinates=(?,?) "
+	q.Names[0] = "point[0]"
+	q.Names[1] = "point[1]"
+	third := q.cachedTupleBindElements()
+	if len(third) != 2 || third[0].base != "point" || third[1].base != "point" {
+		t.Fatalf("tuple metadata was not refreshed after rename: %#v", third)
+	}
+
+	q.Names = append(q.Names, "k")
+	args, err := q.bindMapArgs(map[string]interface{}{
+		"point": [2]int{12, 34},
+		"k":     56,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(args, []interface{}{12, 34, 56}); diff != "" {
+		t.Error("args mismatch", diff)
+	}
+
+	names := []string{"coordinates[0]", "coordinates[1]"}
+	constructed := Query(nil, names)
+	names[0] = "destination[0]"
+	names[1] = "destination[1]"
+	metadata := constructed.cachedTupleBindElements()
+	if len(metadata) != 2 || metadata[0].base != "destination" || metadata[1].base != "destination" {
+		t.Fatalf("tuple metadata was not refreshed after source slice mutation: %#v", metadata)
+	}
+}
+
+func TestQueryxBindMapTupleInCollectionLiteral(t *testing.T) {
+	q := &Queryx{
+		Names:     []string{"point[0]", "point[1]"},
+		Mapper:    DefaultMapper,
+		statement: "UPDATE tbl SET points=[(?,?)] ",
+	}
+
+	args, err := q.bindMapArgs(map[string]interface{}{
+		"point": [2]int{12, 34},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff([]interface{}{12, 34}, args); diff != "" {
+		t.Error("args mismatch", diff)
+	}
 }
 
 func TestQueryxAllWrapped(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -47,11 +47,14 @@ func WrapSession(session *gocql.Session, err error) (Session, error) {
 // a query, see the "Query" function .
 func (s Session) ContextQuery(ctx context.Context, stmt string, names []string) *Queryx {
 	return &Queryx{
-		Query:  s.Session.Query(stmt).WithContext(ctx),
-		Names:  names,
-		Mapper: s.Mapper,
-		tr:     DefaultBindTransformer,
-		strict: DefaultStrict,
+		Query:         s.Session.Query(stmt).WithContext(ctx),
+		Names:         names,
+		Mapper:        s.Mapper,
+		tr:            DefaultBindTransformer,
+		strict:        DefaultStrict,
+		statement:     stmt,
+		tupleElements: tupleBindElements(stmt, names),
+		tupleNames:    append([]string(nil), names...),
 	}
 }
 
@@ -62,11 +65,14 @@ func (s Session) ContextQuery(ctx context.Context, stmt string, names []string) 
 // binding.
 func (s Session) Query(stmt string, names []string) *Queryx {
 	return &Queryx{
-		Query:  s.Session.Query(stmt),
-		Names:  names,
-		Mapper: s.Mapper,
-		tr:     DefaultBindTransformer,
-		strict: DefaultStrict,
+		Query:         s.Session.Query(stmt),
+		Names:         names,
+		Mapper:        s.Mapper,
+		tr:            DefaultBindTransformer,
+		strict:        DefaultStrict,
+		statement:     stmt,
+		tupleElements: tupleBindElements(stmt, names),
+		tupleNames:    append([]string(nil), names...),
 	}
 }
 

--- a/transformer.go
+++ b/transformer.go
@@ -22,6 +22,9 @@ var DefaultBindTransformer Transformer
 // It helps to avoid tombstones when using the same insert/update
 // statement for filled and partially filled named parameters.
 var UnsetEmptyTransformer = func(name string, val interface{}) interface{} {
+	if val == nil {
+		return nil
+	}
 	v := reflect.ValueOf(val)
 	if v.IsZero() {
 		return gocql.UnsetValue

--- a/tuple.go
+++ b/tuple.go
@@ -1,0 +1,603 @@
+// Copyright (C) 2017 ScyllaDB
+// Use of this source code is governed by a ALv2-style
+// license that can be found in the LICENSE file.
+
+package gocqlx
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/scylladb/go-reflectx"
+)
+
+type tupleBindElement struct {
+	base  string
+	index int
+	count int
+}
+
+func parseTupleElementName(name string) (base string, index int, ok bool) {
+	if !strings.HasSuffix(name, "]") {
+		return "", 0, false
+	}
+
+	open := strings.LastIndexByte(name, '[')
+	if open <= 0 {
+		return "", 0, false
+	}
+
+	digits := name[open+1 : len(name)-1]
+	if digits == "" || (len(digits) > 1 && digits[0] == '0') {
+		return "", 0, false
+	}
+	for i := range digits {
+		if digits[i] < '0' || digits[i] > '9' {
+			return "", 0, false
+		}
+	}
+
+	index, err := strconv.Atoi(digits)
+	// The inferred tuple count is index + 1, so the largest int cannot be
+	// represented as a valid tuple element index.
+	if err != nil || index < 0 || index == math.MaxInt {
+		return "", 0, false
+	}
+
+	return name[:open], index, true
+}
+
+func tupleBindElements(stmt string, names []string) []tupleBindElement {
+	if len(names) == 0 {
+		return nil
+	}
+	if stmt == "" {
+		return tupleBindElementsByName(names)
+	}
+
+	elements := make([]tupleBindElement, len(names))
+	for _, group := range tuplePlaceholderGroups(stmt) {
+		if len(group) == 0 || group[len(group)-1] >= len(names) {
+			continue
+		}
+
+		base, _, ok := parseTupleElementName(names[group[0]])
+		if !ok {
+			continue
+		}
+		for index, position := range group {
+			nameBase, nameIndex, nameOK := parseTupleElementName(names[position])
+			if !nameOK || nameBase != base || nameIndex != index {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+
+		for index, position := range group {
+			elements[position] = tupleBindElement{base: base, index: index, count: len(group)}
+		}
+	}
+	return elements
+}
+
+// tupleBindElementsByName preserves tuple binding when the deprecated Query
+// constructor is given a nil gocql.Query. Session-created queries use the CQL
+// statement so collection element names such as "items[0]" are not
+// misclassified.
+func tupleBindElementsByName(names []string) []tupleBindElement {
+	type tupleNames struct {
+		seen  map[int]int
+		count int
+	}
+
+	byBase := make(map[string]*tupleNames)
+	for _, name := range names {
+		base, index, ok := parseTupleElementName(name)
+		if !ok {
+			continue
+		}
+		tuple := byBase[base]
+		if tuple == nil {
+			tuple = &tupleNames{seen: make(map[int]int)}
+			byBase[base] = tuple
+		}
+		tuple.seen[index]++
+		if index+1 > tuple.count {
+			tuple.count = index + 1
+		}
+	}
+
+	elements := make([]tupleBindElement, len(names))
+	for position, name := range names {
+		base, index, ok := parseTupleElementName(name)
+		if !ok {
+			continue
+		}
+		tuple := byBase[base]
+		if len(tuple.seen) != tuple.count || tuple.seen[index] != 1 {
+			continue
+		}
+		elements[position] = tupleBindElement{base: base, index: index, count: tuple.count}
+	}
+	return elements
+}
+
+type tuplePlaceholderFrame struct {
+	positions         []int
+	valid             bool
+	expectPlaceholder bool
+}
+
+func tuplePlaceholderGroups(stmt string) [][]int {
+	var (
+		groups       [][]int
+		stack        []tuplePlaceholderFrame
+		placeholder  int
+		singleQuote  bool
+		doubleQuote  bool
+		lineComment  bool
+		blockComment bool
+		dollarQuote  bool
+		previous     = -1
+	)
+
+	for i := 0; i < len(stmt); i++ {
+		ch := stmt[i]
+		next := byte(0)
+		if i+1 < len(stmt) {
+			next = stmt[i+1]
+		}
+
+		switch {
+		case lineComment:
+			if ch == '\n' || ch == '\r' {
+				lineComment = false
+			}
+			continue
+		case blockComment:
+			if ch == '*' && next == '/' {
+				blockComment = false
+				i++
+			}
+			continue
+		case dollarQuote:
+			if ch == '$' && next == '$' {
+				dollarQuote = false
+				i++
+			}
+			continue
+		case singleQuote:
+			if ch == '\'' {
+				if next == '\'' {
+					i++
+				} else {
+					singleQuote = false
+				}
+			}
+			continue
+		case doubleQuote:
+			if ch == '"' {
+				if next == '"' {
+					i++
+				} else {
+					doubleQuote = false
+				}
+			}
+			continue
+		case (ch == '-' && next == '-') || (ch == '/' && next == '/'):
+			lineComment = true
+			i++
+			continue
+		case ch == '/' && next == '*':
+			blockComment = true
+			i++
+			continue
+		case ch == '\'':
+			invalidateTupleFrame(stack)
+			singleQuote = true
+			continue
+		case ch == '"':
+			invalidateTupleFrame(stack)
+			doubleQuote = true
+			continue
+		case ch == '$' && next == '$':
+			invalidateTupleFrame(stack)
+			dollarQuote = true
+			i++
+			continue
+		}
+
+		switch ch {
+		case '(':
+			invalidateTupleFrame(stack)
+			stack = append(stack, tuplePlaceholderFrame{
+				valid:             isTuplePlaceholderContext(stmt, previous),
+				expectPlaceholder: true,
+			})
+		case ')':
+			if len(stack) == 0 {
+				continue
+			}
+			frame := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if frame.valid && !frame.expectPlaceholder && len(frame.positions) != 0 {
+				groups = append(groups, frame.positions)
+			}
+		case '?':
+			if len(stack) != 0 {
+				frame := &stack[len(stack)-1]
+				if !frame.expectPlaceholder {
+					frame.valid = false
+				}
+				frame.positions = append(frame.positions, placeholder)
+				frame.expectPlaceholder = false
+			}
+			placeholder++
+		case ',':
+			if len(stack) != 0 {
+				frame := &stack[len(stack)-1]
+				if frame.expectPlaceholder {
+					frame.valid = false
+				}
+				frame.expectPlaceholder = true
+			}
+		case ' ', '\t', '\r', '\n':
+		default:
+			invalidateTupleFrame(stack)
+		}
+		if ch != ' ' && ch != '\t' && ch != '\r' && ch != '\n' {
+			previous = i
+		}
+	}
+
+	return groups
+}
+
+func isTuplePlaceholderContext(stmt string, previous int) bool {
+	if previous < 0 {
+		return false
+	}
+
+	switch stmt[previous] {
+	case '(', '[', '{', ':', ',', '=', '<', '>', '!':
+		return true
+	}
+
+	wordEnd := previous + 1
+	for previous >= 0 {
+		ch := stmt[previous]
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') {
+			previous--
+			continue
+		}
+		break
+	}
+	switch strings.ToUpper(stmt[previous+1 : wordEnd]) {
+	case "IN", "CONTAINS", "KEY", "LIKE":
+		return true
+	default:
+		return false
+	}
+}
+
+func invalidateTupleFrame(stack []tuplePlaceholderFrame) {
+	if len(stack) != 0 {
+		stack[len(stack)-1].valid = false
+	}
+}
+
+func traversalByName(mapper *reflectx.Mapper, t reflect.Type, name string) []int {
+	traversals := mapper.TraversalsByName(t, []string{name})
+	if len(traversals) == 0 || len(traversals[0]) == 0 {
+		return nil
+	}
+	return traversals[0]
+}
+
+func fieldTypeByTraversal(t reflect.Type, traversal []int) reflect.Type {
+	t = derefTupleType(t)
+	for _, index := range traversal {
+		if t.Kind() != reflect.Struct || index >= t.NumField() {
+			return nil
+		}
+		t = t.Field(index).Type
+		t = derefTupleType(t)
+	}
+	return t
+}
+
+func pointerTraversals(t reflect.Type, traversal []int) [][]int {
+	t = derefTupleType(t)
+	path := make([]int, 0, len(traversal))
+	var pointers [][]int
+	for _, index := range traversal {
+		if t == nil || t.Kind() != reflect.Struct || index < 0 || index >= t.NumField() {
+			break
+		}
+		fieldType := t.Field(index).Type
+		path = append(path, index)
+		if fieldType.Kind() == reflect.Ptr {
+			pointers = append(pointers, append([]int(nil), path...))
+		}
+		t = derefTupleType(fieldType)
+	}
+	return pointers
+}
+
+func equalTraversal(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func freshPointerByTraversal(value reflect.Value, traversal []int) error {
+	for position, index := range traversal {
+		value = reflect.Indirect(value)
+		if !value.IsValid() || value.Kind() != reflect.Struct || index < 0 || index >= value.NumField() {
+			return fmt.Errorf("invalid pointer field traversal")
+		}
+
+		field := value.Field(index)
+		if position == len(traversal)-1 {
+			if field.Kind() != reflect.Ptr || !field.CanSet() {
+				return fmt.Errorf("cannot replace pointer field in traversal")
+			}
+			return clonePointerChain(field)
+		}
+
+		for field.Kind() == reflect.Ptr {
+			if field.IsNil() {
+				if !field.CanSet() {
+					return fmt.Errorf("cannot allocate pointer field in traversal")
+				}
+				field.Set(reflect.New(field.Type().Elem()))
+			}
+			field = field.Elem()
+		}
+		value = field
+	}
+	return nil
+}
+
+func clonePointerChain(value reflect.Value) error {
+	for value.Kind() == reflect.Ptr {
+		if !value.CanSet() {
+			return fmt.Errorf("cannot replace pointer field in traversal")
+		}
+		replacement := reflect.New(value.Type().Elem())
+		if !value.IsNil() {
+			replacement.Elem().Set(value.Elem())
+		}
+		value.Set(replacement)
+		value = value.Elem()
+	}
+	return nil
+}
+
+func isTupleBindContainerType(t reflect.Type) bool {
+	return isTupleContainerType(t, marshalerInterface)
+}
+
+func isTupleScanContainerType(t reflect.Type) bool {
+	return isTupleContainerType(t, unmarshallerInterface)
+}
+
+func isTupleContainerType(t, customInterface reflect.Type) bool {
+	if t == nil {
+		return false
+	}
+	t = derefTupleType(t)
+	if typeImplements(t, customInterface) || (t.Kind() != reflect.Array && t.Kind() != reflect.Slice) {
+		return false
+	}
+	return t.Elem().Kind() != reflect.Uint8
+}
+
+func tupleElementByName(mapper *reflectx.Mapper, value reflect.Value, name string, tuple tupleBindElement) (reflect.Value, bool, error) {
+	if tuple.count == 0 {
+		return reflect.Value{}, false, nil
+	}
+
+	traversal := traversalByName(mapper, value.Type(), tuple.base)
+	if len(traversal) == 0 {
+		return reflect.Value{}, false, nil
+	}
+
+	field, err := fieldByTraversalReadOnly(value, traversal)
+	if err != nil {
+		return reflect.Value{}, false, fmt.Errorf("could not bind tuple element %q: %w", name, err)
+	}
+	elem, err := tupleBindElementValue(mapper, field, tuple.index, tuple.count)
+	if err != nil {
+		return reflect.Value{}, false, fmt.Errorf("could not bind tuple element %q: %w", name, err)
+	}
+	return elem, true, nil
+}
+
+func tupleBindElementValue(mapper *reflectx.Mapper, value reflect.Value, index, count int) (reflect.Value, error) {
+	t := value.Type()
+	switch {
+	case isTupleBindContainerType(t):
+		return tupleElementValue(value, index, count)
+	case isTupleStructType(t, marshalerInterface):
+		value, err := derefTupleValue(value, false)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		traversals := tupleStructTraversals(mapper, value.Type())
+		if len(traversals) != count {
+			return reflect.Value{}, fmt.Errorf("struct %s has %d mapped fields, expected %d tuple elements", value.Type(), len(traversals), count)
+		}
+		return fieldByTraversalReadOnly(value, traversals[index])
+	default:
+		return reflect.Value{}, fmt.Errorf("expected a non-byte array, slice, or struct with %d mapped fields but got %s", count, t)
+	}
+}
+
+func tupleElementValue(value reflect.Value, index, count int) (reflect.Value, error) {
+	value, err := derefTupleValue(value, false)
+	if err != nil {
+		return reflect.Value{}, err
+	}
+
+	switch value.Kind() {
+	case reflect.Array, reflect.Slice:
+		if value.Kind() == reflect.Slice && value.IsNil() {
+			return reflect.Value{}, fmt.Errorf("nil slice does not match tuple element count %d", count)
+		}
+		if value.Len() != count {
+			return reflect.Value{}, fmt.Errorf("%s length %d does not match tuple element count %d", value.Kind(), value.Len(), count)
+		}
+		return value.Index(index), nil
+	default:
+		return reflect.Value{}, fmt.Errorf("expected array or slice but got %s", value.Kind())
+	}
+}
+
+func tupleElementAddr(value reflect.Value, index, count int) (reflect.Value, error) {
+	value, err := derefTupleValue(value, true)
+	if err != nil {
+		return reflect.Value{}, err
+	}
+
+	switch value.Kind() {
+	case reflect.Array:
+		if value.Len() != count {
+			return reflect.Value{}, fmt.Errorf("array length %d does not match tuple element count %d", value.Len(), count)
+		}
+	case reflect.Slice:
+		if !value.CanSet() {
+			return reflect.Value{}, fmt.Errorf("cannot allocate unsettable slice %s", value.Type())
+		}
+		// Allocate for every row so retained StructScan results do not share a
+		// backing array that is overwritten by the next scan. Tuple elements
+		// are planned in index order, so only the first element starts a row.
+		if index == 0 || value.Len() != count {
+			value.Set(reflect.MakeSlice(value.Type(), count, count))
+		}
+	default:
+		return reflect.Value{}, fmt.Errorf("expected array or slice but got %s", value.Kind())
+	}
+
+	elem := value.Index(index)
+	if !elem.CanAddr() {
+		return reflect.Value{}, fmt.Errorf("cannot address tuple element %d in %s", index, value.Type())
+	}
+	return elem.Addr(), nil
+}
+
+func tupleStructTraversals(mapper *reflectx.Mapper, t reflect.Type) [][]int {
+	t = derefTupleType(t)
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+
+	mapping := mapper.TypeMap(t)
+	var traversals [][]int
+	var appendFields func([]*reflectx.FieldInfo)
+	appendFields = func(fields []*reflectx.FieldInfo) {
+		for _, field := range fields {
+			if field == nil {
+				continue
+			}
+			if field.Embedded {
+				appendFields(field.Children)
+				continue
+			}
+			if visible, ok := mapping.Names[field.Path]; !ok || visible != field {
+				continue
+			}
+			traversals = append(traversals, append([]int(nil), field.Index...))
+		}
+	}
+	appendFields(mapping.Tree.Children)
+	return traversals
+}
+
+func isTupleStructType(t, customInterface reflect.Type) bool {
+	if t == nil {
+		return false
+	}
+	t = derefTupleType(t)
+	return t.Kind() == reflect.Struct && !typeImplements(t, customInterface)
+}
+
+func typeImplements(t, iface reflect.Type) bool {
+	return t.Implements(iface) || reflect.PointerTo(t).Implements(iface)
+}
+
+func derefTupleType(t reflect.Type) reflect.Type {
+	for t != nil && t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t
+}
+
+func fieldByTraversalReadOnly(value reflect.Value, traversal []int) (reflect.Value, error) {
+	for _, index := range traversal {
+		value = reflect.Indirect(value)
+		if !value.IsValid() {
+			return reflect.Value{}, fmt.Errorf("nil pointer in field traversal")
+		}
+		if value.Kind() != reflect.Struct || index < 0 || index >= value.NumField() {
+			return reflect.Value{}, fmt.Errorf("invalid field traversal")
+		}
+		value = value.Field(index)
+	}
+	return value, nil
+}
+
+func derefTupleValue(value reflect.Value, allocate bool) (reflect.Value, error) {
+	if !value.IsValid() {
+		return reflect.Value{}, fmt.Errorf("expected array or slice but got nil")
+	}
+
+	for value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			if !allocate {
+				return reflect.Value{}, fmt.Errorf("nil %s", value.Type())
+			}
+			if !value.CanSet() {
+				return reflect.Value{}, fmt.Errorf("cannot allocate unsettable %s", value.Type())
+			}
+			value.Set(reflect.New(value.Type().Elem()))
+		}
+		value = value.Elem()
+	}
+
+	return value, nil
+}
+
+func tupleElementFromMap(mapper *reflectx.Mapper, m map[string]interface{}, name string, tuple tupleBindElement) (elem interface{}, ok bool, err error) {
+	if tuple.count == 0 {
+		return nil, false, nil
+	}
+
+	value, ok := m[tuple.base]
+	if !ok {
+		return nil, false, nil
+	}
+
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() {
+		return nil, false, fmt.Errorf("could not bind tuple element %q: expected a tuple value in %q but got nil", name, tuple.base)
+	}
+
+	element, err := tupleBindElementValue(mapper, rv, tuple.index, tuple.count)
+	if err != nil {
+		return nil, false, fmt.Errorf("could not bind tuple element %q: %w", name, err)
+	}
+	return element.Interface(), true, nil
+}

--- a/tuple_test.go
+++ b/tuple_test.go
@@ -1,0 +1,758 @@
+// Copyright (C) 2017 ScyllaDB
+// Use of this source code is governed by a ALv2-style
+// license that can be found in the LICENSE file.
+
+package gocqlx
+
+import (
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gocql/gocql"
+	"github.com/google/go-cmp/cmp"
+)
+
+type customTupleMarshaler []int
+
+func (customTupleMarshaler) MarshalCQL(gocql.TypeInfo) ([]byte, error) {
+	return nil, nil
+}
+
+type customTupleUnmarshaler []int
+
+func (*customTupleUnmarshaler) UnmarshalCQL(gocql.TypeInfo, []byte) error {
+	return nil
+}
+
+func TestParseTupleElementName(t *testing.T) {
+	tests := []struct {
+		name      string
+		wantBase  string
+		wantIndex int
+		wantOK    bool
+	}{
+		{name: "c[0]", wantBase: "c", wantOK: true},
+		{name: "c[1]", wantBase: "c", wantIndex: 1, wantOK: true},
+		{name: "c[+1]"},
+		{name: "c[01]"},
+		{name: "c[]"},
+		{name: "c[-1]"},
+		{name: "[0]"},
+		{name: "c[" + strconv.Itoa(math.MaxInt) + "]"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base, index, ok := parseTupleElementName(test.name)
+			if base != test.wantBase || index != test.wantIndex || ok != test.wantOK {
+				t.Fatalf("parseTupleElementName(%q) = (%q, %d, %t), want (%q, %d, %t)", test.name, base, index, ok, test.wantBase, test.wantIndex, test.wantOK)
+			}
+		})
+	}
+}
+
+func TestTupleBindElements(t *testing.T) {
+	tests := []struct {
+		name  string
+		stmt  string
+		names []string
+		want  []tupleBindElement
+	}{
+		{
+			name:  "insert tuple",
+			stmt:  "INSERT INTO tbl (k,c) VALUES (?,(?,?)) ",
+			names: []string{"k", "c[0]", "c[1]"},
+			want: []tupleBindElement{
+				{},
+				{base: "c", count: 2},
+				{base: "c", index: 1, count: 2},
+			},
+		},
+		{
+			name:  "collection element",
+			stmt:  "UPDATE tbl SET items[0]=? ",
+			names: []string{"items[0]"},
+			want:  []tupleBindElement{{}},
+		},
+		{
+			name:  "single element tuple",
+			stmt:  "INSERT INTO tbl (c) VALUES ((?)) ",
+			names: []string{"c[0]"},
+			want:  []tupleBindElement{{base: "c", count: 1}},
+		},
+		{
+			name:  "scalar insert",
+			stmt:  "INSERT INTO tbl (c) VALUES (?) ",
+			names: []string{"c[0]"},
+			want:  []tupleBindElement{{}},
+		},
+		{
+			name:  "function arguments",
+			stmt:  "INSERT INTO tbl (c) VALUES (fn(?,?)) ",
+			names: []string{"c[0]", "c[1]"},
+			want:  []tupleBindElement{{}, {}},
+		},
+		{
+			name:  "tuple and collection element",
+			stmt:  "UPDATE tbl SET c=(?,?),items[0]=? ",
+			names: []string{"c[0]", "c[1]", "items[0]"},
+			want: []tupleBindElement{
+				{base: "c", count: 2},
+				{base: "c", index: 1, count: 2},
+				{},
+			},
+		},
+		{
+			name:  "dollar quoted literal before tuple",
+			stmt:  "INSERT INTO tbl (literal,c) VALUES ($$?$$,(?,?)) ",
+			names: []string{"c[0]", "c[1]"},
+			want: []tupleBindElement{
+				{base: "c", count: 2},
+				{base: "c", index: 1, count: 2},
+			},
+		},
+		{
+			name:  "slash comment before tuple",
+			stmt:  "UPDATE tbl SET c=// ? is not a marker\n(?,?) ",
+			names: []string{"c[0]", "c[1]"},
+			want: []tupleBindElement{
+				{base: "c", count: 2},
+				{base: "c", index: 1, count: 2},
+			},
+		},
+		{
+			name:  "block comment between operator and tuple",
+			stmt:  "UPDATE tbl SET c=/* tuple follows */(?,?) ",
+			names: []string{"c[0]", "c[1]"},
+			want: []tupleBindElement{
+				{base: "c", count: 2},
+				{base: "c", index: 1, count: 2},
+			},
+		},
+		{
+			name:  "tuple first in collection literal",
+			stmt:  "UPDATE tbl SET values=[(?,?)] ",
+			names: []string{"value[0]", "value[1]"},
+			want: []tupleBindElement{
+				{base: "value", count: 2},
+				{base: "value", index: 1, count: 2},
+			},
+		},
+		{
+			name:  "tuple in UDT literal",
+			stmt:  "UPDATE tbl SET value={point:(?,?)} ",
+			names: []string{"point[0]", "point[1]"},
+			want: []tupleBindElement{
+				{base: "point", count: 2},
+				{base: "point", index: 1, count: 2},
+			},
+		},
+		{
+			name:  "non-canonical name",
+			stmt:  "UPDATE tbl SET c=(?,?) ",
+			names: []string{"c[0]", "c[+1]"},
+			want:  []tupleBindElement{{}, {}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := tupleBindElements(test.stmt, test.names)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("tuple bind metadata = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestTupleContainerTypes(t *testing.T) {
+	if isTupleBindContainerType(reflect.TypeOf(customTupleMarshaler{})) {
+		t.Fatal("custom marshaler must not be decomposed")
+	}
+	if isTupleScanContainerType(reflect.TypeOf(customTupleUnmarshaler{})) {
+		t.Fatal("custom unmarshaler must not be decomposed")
+	}
+	if isTupleBindContainerType(reflect.TypeOf([]byte{})) || isTupleScanContainerType(reflect.TypeOf([2]byte{})) {
+		t.Fatal("byte sequences must not be tuple containers")
+	}
+	if !isTupleBindContainerType(reflect.TypeOf([][]byte{})) {
+		t.Fatal("a slice of blobs must be a tuple container")
+	}
+}
+
+func TestIterxTupleStructScanPlan(t *testing.T) {
+	columns := []gocql.ColumnInfo{
+		{
+			Name:     "k",
+			TypeInfo: gocql.NewNativeType(0, gocql.TypeInt),
+		},
+		{
+			Name: "c",
+			TypeInfo: gocql.NewTupleType(
+				gocql.NewNativeType(0, gocql.TypeTuple),
+				gocql.NewNativeType(0, gocql.TypeInt),
+				gocql.NewNativeType(0, gocql.TypeInt),
+			),
+		},
+	}
+
+	t.Run("array", func(t *testing.T) {
+		type row struct {
+			K int
+			C [2]int
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(plan.columns, []string{"k", "c[0]", "c[1]"}); diff != "" {
+			t.Error("names mismatch", diff)
+		}
+		if diff := cmp.Diff(plan.tupleIndexes, []int{-1, 0, 1}); diff != "" {
+			t.Error("tuple indexes mismatch", diff)
+		}
+		if diff := cmp.Diff(plan.tupleCounts, []int{0, 2, 2}); diff != "" {
+			t.Error("tuple counts mismatch", diff)
+		}
+
+		var r row
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&r), &plan); err != nil {
+			t.Fatal(err)
+		}
+
+		reflect.ValueOf(plan.values[1]).Elem().SetInt(12)
+		reflect.ValueOf(plan.values[2]).Elem().SetInt(34)
+		if diff := cmp.Diff(r.C, [2]int{12, 34}); diff != "" {
+			t.Error("tuple value mismatch", diff)
+		}
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		type row struct {
+			K int
+			C []int
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var r row
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&r), &plan); err != nil {
+			t.Fatal(err)
+		}
+
+		reflect.ValueOf(plan.values[1]).Elem().SetInt(56)
+		reflect.ValueOf(plan.values[2]).Elem().SetInt(78)
+		if diff := cmp.Diff(r.C, []int{56, 78}); diff != "" {
+			t.Error("tuple value mismatch", diff)
+		}
+	})
+
+	t.Run("interface slice", func(t *testing.T) {
+		columns := []gocql.ColumnInfo{
+			{
+				Name: "c",
+				TypeInfo: gocql.NewTupleType(
+					gocql.NewNativeType(0, gocql.TypeTuple),
+					gocql.NewNativeType(0, gocql.TypeInt),
+					gocql.NewNativeType(0, gocql.TypeText),
+				),
+			},
+		}
+		type row struct {
+			C []interface{}
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var r row
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&r), &plan); err != nil {
+			t.Fatal(err)
+		}
+
+		tuple := columns[0].TypeInfo.(gocql.TupleTypeInfo)
+		intData := []byte{0, 0, 0, 42}
+		textData := []byte("answer")
+		if err := gocql.Unmarshal(tuple.Elems[0], intData, plan.values[0]); err != nil {
+			t.Fatal(err)
+		}
+		if err := gocql.Unmarshal(tuple.Elems[1], textData, plan.values[1]); err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(r.C, []interface{}{42, "answer"}); diff != "" {
+			t.Error("tuple value mismatch", diff)
+		}
+	})
+
+	t.Run("element fields", func(t *testing.T) {
+		type row struct {
+			K  int
+			C0 int `db:"c[0]"`
+			C1 int `db:"c[1]"`
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var r row
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&r), &plan); err != nil {
+			t.Fatal(err)
+		}
+
+		reflect.ValueOf(plan.values[1]).Elem().SetInt(90)
+		reflect.ValueOf(plan.values[2]).Elem().SetInt(12)
+		if diff := cmp.Diff(row{C0: 90, C1: 12}, r); diff != "" {
+			t.Error("tuple value mismatch", diff)
+		}
+	})
+
+	t.Run("interface element fields", func(t *testing.T) {
+		type row struct {
+			K  int
+			C0 interface{} `db:"c[0]"`
+			C1 interface{} `db:"c[1]"`
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(plan.tupleCounts, []int{0, 2, 2}); diff != "" {
+			t.Error("tuple counts mismatch", diff)
+		}
+
+		var r row
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&r), &plan); err != nil {
+			t.Fatal(err)
+		}
+
+		tuple := columns[1].TypeInfo.(gocql.TupleTypeInfo)
+		if err := gocql.Unmarshal(tuple.Elems[0], []byte{0, 0, 0, 34}, plan.values[1]); err != nil {
+			t.Fatal(err)
+		}
+		if err := gocql.Unmarshal(tuple.Elems[1], []byte{0, 0, 0, 56}, plan.values[2]); err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(row{C0: 34, C1: 56}, r); diff != "" {
+			t.Error("tuple value mismatch", diff)
+		}
+	})
+
+	t.Run("struct interface fields", func(t *testing.T) {
+		type tupleValue struct {
+			First  interface{}
+			Second interface{}
+		}
+		type row struct {
+			C tupleValue
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var r row
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&r), &plan); err != nil {
+			t.Fatal(err)
+		}
+
+		tuple := columns[1].TypeInfo.(gocql.TupleTypeInfo)
+		if err := gocql.Unmarshal(tuple.Elems[0], []byte{0, 0, 0, 34}, plan.values[1]); err != nil {
+			t.Fatal(err)
+		}
+		if err := gocql.Unmarshal(tuple.Elems[1], []byte{0, 0, 0, 56}, plan.values[2]); err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(row{C: tupleValue{First: 34, Second: 56}}, r); diff != "" {
+			t.Error("tuple value mismatch", diff)
+		}
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		type tupleValue struct {
+			Field1 int
+			Field2 int
+		}
+		type row struct {
+			K int
+			C tupleValue
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var r row
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&r), &plan); err != nil {
+			t.Fatal(err)
+		}
+
+		reflect.ValueOf(plan.values[1]).Elem().SetInt(23)
+		reflect.ValueOf(plan.values[2]).Elem().SetInt(45)
+		if diff := cmp.Diff(tupleValue{Field1: 23, Field2: 45}, r.C); diff != "" {
+			t.Error("tuple value mismatch", diff)
+		}
+	})
+
+	t.Run("struct mapper fields", func(t *testing.T) {
+		type embedded struct {
+			First int
+		}
+		type tupleValue struct {
+			embedded
+			Ignored string `db:"-"`
+			Second  int
+		}
+		type row struct {
+			C tupleValue
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var r row
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&r), &plan); err != nil {
+			t.Fatal(err)
+		}
+		reflect.ValueOf(plan.values[1]).Elem().SetInt(23)
+		reflect.ValueOf(plan.values[2]).Elem().SetInt(45)
+		if r.C.First != 23 || r.C.Second != 45 || r.C.Ignored != "" {
+			t.Fatalf("tuple value mismatch: %#v", r.C)
+		}
+	})
+
+	t.Run("container takes precedence over element fields", func(t *testing.T) {
+		type row struct {
+			K  int
+			C  [2]int
+			C0 int `db:"c[0]"`
+			C1 int `db:"c[1]"`
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var r row
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&r), &plan); err != nil {
+			t.Fatal(err)
+		}
+
+		reflect.ValueOf(plan.values[1]).Elem().SetInt(67)
+		reflect.ValueOf(plan.values[2]).Elem().SetInt(89)
+		if diff := cmp.Diff(row{C: [2]int{67, 89}}, r); diff != "" {
+			t.Error("tuple value mismatch", diff)
+		}
+	})
+
+	t.Run("byte slice", func(t *testing.T) {
+		byteColumns := []gocql.ColumnInfo{
+			{
+				Name: "c",
+				TypeInfo: gocql.NewTupleType(
+					gocql.NewNativeType(0, gocql.TypeTuple),
+					gocql.NewNativeType(0, gocql.TypeTinyInt),
+					gocql.NewNativeType(0, gocql.TypeTinyInt),
+				),
+			},
+		}
+		type row struct {
+			C []byte
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		_, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), byteColumns)
+		if err == nil || !strings.Contains(err.Error(), "expected a non-byte array") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("unsupported same-name field takes precedence", func(t *testing.T) {
+		type row struct {
+			C  int
+			C0 int `db:"c[0]"`
+			C1 int `db:"c[1]"`
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		_, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+		if err == nil || !strings.Contains(err.Error(), `cannot scan tuple column "c" into int`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("tuple struct rejects unexported field", func(t *testing.T) {
+		type tupleValue struct {
+			Exported int
+			private  int
+		}
+		type row struct {
+			C tupleValue
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		_, err := iter.buildStructScanPlan(reflect.TypeOf(row{C: tupleValue{private: 1}}), columns)
+		if err == nil || !strings.Contains(err.Error(), `struct has 1 mapped fields, expected 2 tuple elements`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missing tuple elements keep scan alignment", func(t *testing.T) {
+		type row struct {
+			K int
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(plan.fields[1]) != 0 || len(plan.fields[2]) != 0 {
+			t.Fatal("unexpected tuple element traversal")
+		}
+		if plan.values[1] == nil || plan.values[2] == nil {
+			t.Fatal("missing tuple elements must have discard destinations")
+		}
+	})
+
+	t.Run("missing custom tuple elements keep scan alignment", func(t *testing.T) {
+		customColumns := []gocql.ColumnInfo{
+			{
+				Name: "c",
+				TypeInfo: gocql.NewTupleType(
+					gocql.NewNativeType(0, gocql.TypeTuple),
+					gocql.NewCustomType(0, gocql.TypeCustom, "example.CustomType"),
+				),
+			},
+		}
+		type row struct {
+			K int
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), customColumns)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(plan.fields[0]) != 0 || plan.values[0] == nil {
+			t.Fatal("missing custom tuple element must have a discard destination")
+		}
+		custom := customColumns[0].TypeInfo.(gocql.TupleTypeInfo).Elems[0]
+		if err := gocql.Unmarshal(custom, []byte("ignored"), plan.values[0]); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("array arity mismatch", func(t *testing.T) {
+		type row struct {
+			K int
+			C [3]int
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		_, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+		if err == nil || !strings.Contains(err.Error(), `array length 3 does not match tuple element count 2`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("slice allocation per row", func(t *testing.T) {
+		type row struct {
+			C []int
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns[1:])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var current row
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&current), &plan); err != nil {
+			t.Fatal(err)
+		}
+		reflect.ValueOf(plan.values[0]).Elem().SetInt(12)
+		reflect.ValueOf(plan.values[1]).Elem().SetInt(34)
+		first := current
+
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&current), &plan); err != nil {
+			t.Fatal(err)
+		}
+		reflect.ValueOf(plan.values[0]).Elem().SetInt(56)
+		reflect.ValueOf(plan.values[1]).Elem().SetInt(78)
+
+		if diff := cmp.Diff([]int{12, 34}, first.C); diff != "" {
+			t.Error("retained row was overwritten", diff)
+		}
+		if diff := cmp.Diff([]int{56, 78}, current.C); diff != "" {
+			t.Error("current row mismatch", diff)
+		}
+	})
+}
+
+func TestIterxOrdinaryStructScanPlan(t *testing.T) {
+	columns := []gocql.ColumnInfo{{
+		Name:     "k",
+		TypeInfo: gocql.NewNativeType(0, gocql.TypeInt),
+	}}
+	type row struct {
+		K int
+	}
+
+	iter := &Iterx{Mapper: DefaultMapper}
+	plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), columns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var current row
+	if err := iter.fieldsByTraversal(reflect.ValueOf(&current), &plan); err != nil {
+		t.Fatal(err)
+	}
+	reflect.ValueOf(plan.values[0]).Elem().SetInt(42)
+	if current.K != 42 {
+		t.Fatalf("ordinary field=%d, want 42", current.K)
+	}
+}
+
+func TestIterxTuplePointersAreDeferredAndFresh(t *testing.T) {
+	tupleColumn := []gocql.ColumnInfo{{
+		Name: "c",
+		TypeInfo: gocql.NewTupleType(
+			gocql.NewNativeType(0, gocql.TypeTuple),
+			gocql.NewNativeType(0, gocql.TypeInt),
+			gocql.NewNativeType(0, gocql.TypeInt),
+		),
+	}}
+
+	t.Run("no row preserves tuple struct pointer", func(t *testing.T) {
+		type coordinates struct {
+			X int
+			Y int
+		}
+		type row struct {
+			C *coordinates
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), tupleColumn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		original := &coordinates{X: 9, Y: 10}
+		dest := row{C: original}
+		if !plan.deferValues {
+			t.Fatal("tuple struct destination preparation was not deferred")
+		}
+		staged := reflect.New(reflect.TypeOf(dest))
+		staged.Elem().Set(reflect.ValueOf(dest))
+		if err := iter.fieldsByTraversal(staged, &plan); err != nil {
+			t.Fatal(err)
+		}
+		if dest.C != original || *dest.C != (coordinates{X: 9, Y: 10}) {
+			t.Fatalf("preparing staged scan changed destination: pointer=%p value=%#v", dest.C, *dest.C)
+		}
+		stagedRow := staged.Elem().Interface().(row)
+		if stagedRow.C == original {
+			t.Fatal("staged scan reused tuple struct pointer")
+		}
+	})
+
+	t.Run("retained pointer tuple rows do not alias", func(t *testing.T) {
+		type row struct {
+			C *[2]int
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), tupleColumn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var current row
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&current), &plan); err != nil {
+			t.Fatal(err)
+		}
+		reflect.ValueOf(plan.values[0]).Elem().SetInt(1)
+		reflect.ValueOf(plan.values[1]).Elem().SetInt(2)
+		retained := current
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&current), &plan); err != nil {
+			t.Fatal(err)
+		}
+		reflect.ValueOf(plan.values[0]).Elem().SetInt(3)
+		reflect.ValueOf(plan.values[1]).Elem().SetInt(4)
+		if retained.C == current.C {
+			t.Fatal("tuple pointer reused across rows")
+		}
+		if *retained.C != [2]int{1, 2} || *current.C != [2]int{3, 4} {
+			t.Fatalf("rows overwritten: retained=%v current=%v", *retained.C, *current.C)
+		}
+	})
+
+	t.Run("retained tuple structs with embedded pointers do not alias", func(t *testing.T) {
+		type Elements struct {
+			X int
+			Y int
+		}
+		type coordinates struct {
+			*Elements
+		}
+		type row struct {
+			C coordinates
+		}
+
+		iter := &Iterx{Mapper: DefaultMapper}
+		plan, err := iter.buildStructScanPlan(reflect.TypeOf(row{}), tupleColumn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		current := row{C: coordinates{Elements: &Elements{}}}
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&current), &plan); err != nil {
+			t.Fatal(err)
+		}
+		reflect.ValueOf(plan.values[0]).Elem().SetInt(1)
+		reflect.ValueOf(plan.values[1]).Elem().SetInt(2)
+		retained := current
+
+		if err := iter.fieldsByTraversal(reflect.ValueOf(&current), &plan); err != nil {
+			t.Fatal(err)
+		}
+		reflect.ValueOf(plan.values[0]).Elem().SetInt(3)
+		reflect.ValueOf(plan.values[1]).Elem().SetInt(4)
+		if retained.C.Elements == current.C.Elements {
+			t.Fatal("embedded tuple pointer reused across rows")
+		}
+		if *retained.C.Elements != (Elements{X: 1, Y: 2}) || *current.C.Elements != (Elements{X: 3, Y: 4}) {
+			t.Fatalf("rows overwritten: retained=%v current=%v", *retained.C.Elements, *current.C.Elements)
+		}
+	})
+}


### PR DESCRIPTION
Closes #152

## Summary
- bind tuple placeholder names such as `c[0]` from non-byte array/slice and tuple-shaped struct fields, plus map values keyed by `c`
- expand tuple result columns into array, slice, or tuple-shaped struct fields, with explicit `db:"c[i]"` fields as fallback
- preserve tuple destinations when scans are exhausted or return no rows
- recognize tuple markers across supported CQL literals, comments, collection literals, and UDT literals
- cache tuple bind metadata per `Queryx` while retaining the low-allocation ordinary binding and scan paths
- reject byte sequences as tuple containers and preserve null/zero tuple elements through bind transformers

## Scope limitations
- Same-name tuple-shaped struct destinations are supported when they have one mapper-visible positional field per tuple element. Nested generated tuple type support remains tracked by #375 and scylladb/gocql#956.
- `[]byte` and byte arrays are scalar byte sequences, not tuple containers. Use `[][]byte` or an array/slice of non-byte elements for tuple values.
- Validation of non-positive tuple placeholder counts is pre-existing builder behavior and is intentionally deferred to #399.
- General `interface{}` destination support for ordinary, non-tuple struct scans is pre-existing behavior and is intentionally deferred to #400.

The deferred items are kept out of this PR to avoid expanding its scope beyond tuple array/slice support.

## Tests
- unit and race tests for the affected packages
- `go vet ./...`
- `go test -tags integration -run=NONE ./...`
- binding and scan-plan benchmarks
