### PR TITLE
queryx: add unsafe scan mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,35 @@ fmt.Println(people)
 // stdout: [{Michał Matczuk [michal@scylladb.com]}]
 ```
 
+## Strict struct scanning
+
+By default, GocqlX ignores result columns that do not map to exported fields in
+the destination struct. Use `Strict` to catch schema or query drift when scanning
+structs:
+
+```go
+var p Person
+q := session.Query(`SELECT first_name, last_name, email, age FROM person`, nil).Strict()
+if err := q.GetRelease(&p); err != nil {
+	log.Fatal(err) // age has no matching Person field
+}
+```
+
+Set `gocqlx.DefaultStrict = true` to make new queries strict by default. Use
+`Unsafe` on a query or iterator to ignore unmapped columns for that query or
+iterator instance:
+
+```go
+var p Person
+q := session.Query(`SELECT * FROM person`, nil).Unsafe()
+if err := q.GetRelease(&p); err != nil {
+	log.Fatal(err)
+}
+```
+
+When binding UDT values with `Queryx.Bind`, call `Unsafe` before `Bind` so the
+UDT wrapper is created in unsafe mode.
+
 ## Generating table metadata with schemagen
 
 Installation

--- a/iterx.go
+++ b/iterx.go
@@ -13,8 +13,11 @@ import (
 	"github.com/scylladb/go-reflectx"
 )
 
-// DefaultStrict disables the behavior of forcing queries and iterators to ignore
-// missing fields for all queries. See Strict below for more information.
+// DefaultStrict makes newly created queries use strict struct and UDT mapping.
+// In strict mode, struct scans report an error when a result column has no
+// matching destination field, and UDT marshal/unmarshal reports an error when a
+// UDT field name has no matching struct field. Use Queryx.Unsafe or
+// Iterx.Unsafe to disable strict mode for an individual query or iterator.
 var DefaultStrict bool
 
 // Iterx is a wrapper around gocql.Iter which adds struct scanning capabilities.
@@ -31,11 +34,22 @@ type Iterx struct {
 	applied    bool
 }
 
-// Strict forces the iterator to disable ignoring missing fields. In Strict mode
-// when scanning a struct if result row has a column that cannot be mapped to any
-// destination field an error is reported. By default such columns are ignored.
+// Strict makes the iterator use strict struct and UDT mapping. Struct scans
+// report an error when a result column cannot be mapped to any destination
+// field, and UDT marshal/unmarshal reports an error when a UDT field name has
+// no matching struct field. By default unmatched names are ignored unless
+// DefaultStrict is enabled. Use Unsafe to disable strict mode again for this
+// iterator.
 func (iter *Iterx) Strict() *Iterx {
 	iter.strict = true
+	return iter
+}
+
+// Unsafe makes the iterator ignore result columns and UDT fields that cannot be
+// mapped to destination struct fields. It can override DefaultStrict or a prior
+// Strict call; the last Strict or Unsafe call on the iterator wins.
+func (iter *Iterx) Unsafe() *Iterx {
+	iter.strict = false
 	return iter
 }
 

--- a/iterx_test.go
+++ b/iterx_test.go
@@ -760,6 +760,16 @@ func TestIterxStrict(t *testing.T) {
 		golden = "missing destination name \"testtextunbound\" in gocqlx_test.StrictTable"
 	)
 
+	setDefaultStrict := func(t *testing.T, strict bool) {
+		t.Helper()
+
+		defaultStrict := gocqlx.DefaultStrict
+		gocqlx.DefaultStrict = strict
+		t.Cleanup(func() {
+			gocqlx.DefaultStrict = defaultStrict
+		})
+	}
+
 	t.Run("get strict", func(t *testing.T) {
 		var v StrictTable
 		err := session.Query(stmt, nil).Strict().Get(&v)
@@ -776,6 +786,100 @@ func TestIterxStrict(t *testing.T) {
 		}
 		if cap(v) > 0 {
 			t.Fatalf("Select() effect alloc cap=%d expected 0", cap(v))
+		}
+	})
+
+	t.Run("get default strict", func(t *testing.T) {
+		setDefaultStrict(t, true)
+
+		var v StrictTable
+		err := session.Query(stmt, nil).Get(&v)
+		if err == nil || !strings.HasPrefix(err.Error(), golden) {
+			t.Fatalf("Get() error=%q expected %s", err, golden)
+		}
+	})
+
+	t.Run("get unsafe", func(t *testing.T) {
+		var v StrictTable
+		err := session.Query(stmt, nil).Strict().Unsafe().Get(&v)
+		if err != nil {
+			t.Fatal("Get() failed:", err)
+		}
+		if diff := cmp.Diff(m, v); diff != "" {
+			t.Fatalf("Get()=%+v expected %+v, diff: %s", v, m, diff)
+		}
+	})
+
+	t.Run("get unsafe with default strict", func(t *testing.T) {
+		setDefaultStrict(t, true)
+
+		var v StrictTable
+		err := session.Query(stmt, nil).Unsafe().Get(&v)
+		if err != nil {
+			t.Fatal("Get() failed:", err)
+		}
+		if diff := cmp.Diff(m, v); diff != "" {
+			t.Fatalf("Get()=%+v expected %+v, diff: %s", v, m, diff)
+		}
+	})
+
+	t.Run("select unsafe", func(t *testing.T) {
+		var v []StrictTable
+		err := session.Query(stmt, nil).Strict().Unsafe().SelectRelease(&v)
+		if err != nil {
+			t.Fatal("SelectRelease() failed:", err)
+		}
+		if len(v) != 1 {
+			t.Fatalf("SelectRelease()=%+v expected 1 row got %d", v, len(v))
+		}
+		if diff := cmp.Diff(m, v[0]); diff != "" {
+			t.Fatalf("SelectRelease()[0]=%+v expected %+v, diff: %s", v[0], m, diff)
+		}
+	})
+
+	t.Run("select unsafe with default strict", func(t *testing.T) {
+		setDefaultStrict(t, true)
+
+		var v []StrictTable
+		err := session.Query(stmt, nil).Unsafe().SelectRelease(&v)
+		if err != nil {
+			t.Fatal("SelectRelease() failed:", err)
+		}
+		if len(v) != 1 {
+			t.Fatalf("SelectRelease()=%+v expected 1 row got %d", v, len(v))
+		}
+		if diff := cmp.Diff(m, v[0]); diff != "" {
+			t.Fatalf("SelectRelease()[0]=%+v expected %+v, diff: %s", v[0], m, diff)
+		}
+	})
+
+	t.Run("iter unsafe with default strict", func(t *testing.T) {
+		setDefaultStrict(t, true)
+
+		var v []StrictTable
+		err := session.Query(stmt, nil).Iter().Unsafe().Select(&v)
+		if err != nil {
+			t.Fatal("Select() failed:", err)
+		}
+		if len(v) != 1 {
+			t.Fatalf("Select()=%+v expected 1 row got %d", v, len(v))
+		}
+		if diff := cmp.Diff(m, v[0]); diff != "" {
+			t.Fatalf("Select()[0]=%+v expected %+v, diff: %s", v[0], m, diff)
+		}
+	})
+
+	t.Run("iter unsafe", func(t *testing.T) {
+		var v []StrictTable
+		err := session.Query(stmt, nil).Iter().Strict().Unsafe().Select(&v)
+		if err != nil {
+			t.Fatal("Select() failed:", err)
+		}
+		if len(v) != 1 {
+			t.Fatalf("Select()=%+v expected 1 row got %d", v, len(v))
+		}
+		if diff := cmp.Diff(m, v[0]); diff != "" {
+			t.Fatalf("Select()[0]=%+v expected %+v, diff: %s", v[0], m, diff)
 		}
 	})
 

--- a/queryx.go
+++ b/queryx.go
@@ -378,10 +378,22 @@ func (q *Queryx) Iter() *Iterx {
 	}
 }
 
-// Strict forces the query and iterators to report an error if there are missing fields.
-// By default when scanning a struct if result row has a column that cannot be mapped to
-// any destination it is ignored. With strict error is reported.
+// Strict makes the query and iterators created from it use strict struct and UDT
+// mapping. Struct scans report an error when a result column cannot be mapped
+// to any destination field. UDT marshal/unmarshal reports an error when a UDT
+// field name has no matching struct field. By default these unmatched names are
+// ignored unless DefaultStrict is enabled. Use Unsafe to disable strict mode
+// again for this query.
 func (q *Queryx) Strict() *Queryx {
 	q.strict = true
+	return q
+}
+
+// Unsafe makes the query and iterators created from it ignore result columns and
+// UDT fields that cannot be mapped to destination struct fields. It can override
+// DefaultStrict or a prior Strict call for later scans and binds. For bound UDT
+// values, call Unsafe before Bind so the UDT wrapper is created in unsafe mode.
+func (q *Queryx) Unsafe() *Queryx {
+	q.strict = false
 	return q
 }

--- a/queryx_test.go
+++ b/queryx_test.go
@@ -212,6 +212,68 @@ func TestQueryxBindMap(t *testing.T) {
 	})
 }
 
+func TestQueryxStrictUnsafe(t *testing.T) {
+	defaultStrict := DefaultStrict
+	t.Cleanup(func() {
+		DefaultStrict = defaultStrict
+	})
+
+	DefaultStrict = false
+	q := Query(nil, nil)
+	if q.strict {
+		t.Fatal("Query() strict=true, expected false with DefaultStrict disabled")
+	}
+	if got := q.Strict(); got != q {
+		t.Fatal("Strict() did not return receiver")
+	}
+	if !q.strict {
+		t.Fatal("Strict() did not enable strict mode")
+	}
+	if got := q.Unsafe(); got != q {
+		t.Fatal("Unsafe() did not return receiver")
+	}
+	if q.strict {
+		t.Fatal("Unsafe() did not disable strict mode")
+	}
+
+	DefaultStrict = true
+	q = Query(nil, nil)
+	if !q.strict {
+		t.Fatal("Query() strict=false, expected true with DefaultStrict enabled")
+	}
+	q.Unsafe()
+	if q.strict {
+		t.Fatal("Unsafe() did not override DefaultStrict")
+	}
+	q.Strict()
+	if !q.strict {
+		t.Fatal("Strict() did not override Unsafe()")
+	}
+}
+
+func TestIterxStrictUnsafe(t *testing.T) {
+	iter := &Iterx{}
+	if iter.strict {
+		t.Fatal("Iterx strict=true, expected false by default")
+	}
+	if got := iter.Strict(); got != iter {
+		t.Fatal("Strict() did not return receiver")
+	}
+	if !iter.strict {
+		t.Fatal("Strict() did not enable strict mode")
+	}
+	if got := iter.Unsafe(); got != iter {
+		t.Fatal("Unsafe() did not return receiver")
+	}
+	if iter.strict {
+		t.Fatal("Unsafe() did not disable strict mode")
+	}
+	iter.Strict()
+	if !iter.strict {
+		t.Fatal("Strict() did not override Unsafe()")
+	}
+}
+
 func TestQueryxAllWrapped(t *testing.T) {
 	var (
 		gocqlQueryPtr = reflect.TypeOf((*gocql.Query)(nil))


### PR DESCRIPTION
## Summary
- add `Unsafe()` to `Queryx` so callers can opt out of strict missing-field checks before `Get`, `Select`, or `SelectRelease`
- add `Unsafe()` to `Iterx` for the equivalent iterator-level opt-out
- cover strict-to-unsafe query and iterator flows in the existing strict scan tests

Fixes #365

## Testing
- `go test $(go list ./... | rg -v '/cmd/schemagen$')`\n- `go test ./...` fails locally because `cmd/schemagen` expects Scylla/Cassandra on `127.0.0.1:9042`