### PR TITLE
schemagen: ignore internal paxos tables

### DIFF
--- a/cmd/schemagen/schemagen.go
+++ b/cmd/schemagen/schemagen.go
@@ -104,15 +104,23 @@ func renderTemplate(md *gocql.KeyspaceMetadata) ([]byte, error) {
 	}
 
 	// Then remove all tables, views, and indices if their names match the
-	// filter.
+	// filter. Also skip internal Paxos tables created by LWT.
 	ignoredNames := make(map[string]struct{})
 	for _, ignoredName := range strings.Split(*flagIgnoreNames, ",") {
+		if ignoredName == "" {
+			continue
+		}
 		ignoredNames[ignoredName] = struct{}{}
 	}
 	for name := range ignoredNames {
 		delete(md.Tables, name)
 		delete(md.Views, name)
 		delete(md.Indexes, name)
+	}
+	for name := range md.Tables {
+		if strings.HasSuffix(name, "$paxos") {
+			delete(md.Tables, name)
+		}
 	}
 
 	removeUnusedUserTypes(md)

--- a/cmd/schemagen/schemagen_test.go
+++ b/cmd/schemagen/schemagen_test.go
@@ -209,6 +209,52 @@ func TestRenderTemplateRetainsNestedUserTypes(t *testing.T) {
 	}
 }
 
+func TestRenderTemplateIgnoresPaxosTables(t *testing.T) {
+	pkgname := *flagPkgname
+	ignoreNames := *flagIgnoreNames
+	ignoreIndexes := *flagIgnoreIndexes
+	t.Cleanup(func() {
+		*flagPkgname = pkgname
+		*flagIgnoreNames = ignoreNames
+		*flagIgnoreIndexes = ignoreIndexes
+	})
+
+	*flagPkgname = "schemagentest"
+	*flagIgnoreNames = ""
+	*flagIgnoreIndexes = false
+
+	idColumn := &gocql.ColumnMetadata{Name: "id", Type: "uuid"}
+	emailColumn := &gocql.ColumnMetadata{Name: "email", Type: "text"}
+	paxosColumn := &gocql.ColumnMetadata{Name: "row_key", Type: "blob"}
+	b, err := renderTemplate(&gocql.KeyspaceMetadata{
+		Tables: map[string]*gocql.TableMetadata{
+			"users": {
+				Name:           "users",
+				Columns:        map[string]*gocql.ColumnMetadata{"id": idColumn, "email": emailColumn},
+				OrderedColumns: []string{"id", "email"},
+				PartitionKey:   []*gocql.ColumnMetadata{idColumn},
+			},
+			"users_by_email$paxos": {
+				Name:           "users_by_email$paxos",
+				Columns:        map[string]*gocql.ColumnMetadata{"row_key": paxosColumn},
+				OrderedColumns: []string{"row_key"},
+				PartitionKey:   []*gocql.ColumnMetadata{paxosColumn},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	source := string(b)
+	if !strings.Contains(source, "Users = table.New") {
+		t.Fatalf("generated source does not include user table:\n%s", source)
+	}
+	if strings.Contains(source, "paxos") {
+		t.Fatalf("generated source includes internal Paxos table:\n%s", source)
+	}
+}
+
 func TestRenderTemplateRejectsNonComparableMapKeys(t *testing.T) {
 	pkgname := *flagPkgname
 	ignoreNames := *flagIgnoreNames


### PR DESCRIPTION
## Summary
- skip internal `$paxos` tables while preparing schemagen metadata
- keep the existing `-ignore-names` filtering behavior and skip empty ignore entries
- add a render-level regression test for keyspaces containing LWT Paxos tables

Fixes #362

## Testing
- `go test ./cmd/schemagen -run 'TestRenderTemplate(IgnoresPaxosTables|RetainsNestedUserTypes|RejectsNonComparableMapKeys)'`\n- `go test $(go list ./... | rg -v '/cmd/schemagen$')`