### PR TITLE
examples: add batch and update flows

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gocql/gocql"
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/inf.v0"
 
@@ -24,7 +25,7 @@ import (
 )
 
 // Running examples locally:
-// make run-scylla
+// make start-scylla
 // make run-examples
 func TestExample(t *testing.T) {
 	cluster := gocqlxtest.CreateCluster()
@@ -38,6 +39,8 @@ func TestExample(t *testing.T) {
 	_ = session.ExecStmt(`DROP KEYSPACE examples`)
 
 	basicCreateAndPopulateKeyspace(t, session, "examples")
+	basicBatchInsertStructs(t, session, "examples")
+	basicUpdateWithTableModel(t, session, "examples")
 	createAndPopulateKeyspaceAllTypes(t, session)
 	basicReadScyllaVersion(t, session)
 
@@ -77,10 +80,7 @@ type PlaylistItem struct {
 	SongID gocql.UUID
 }
 
-// This example shows how to use query builders and table models to build
-// queries. It uses "BindStruct" function for parameter binding and "Select"
-// function for loading data to a slice.
-func basicCreateAndPopulateKeyspace(t *testing.T, session gocqlx.Session, keyspace string) {
+func createMusicTables(t *testing.T, session gocqlx.Session, keyspace string) {
 	t.Helper()
 
 	if err := gocqlxtest.CreateKeyspaceIfNotExists(session, keyspace); err != nil {
@@ -108,14 +108,33 @@ func basicCreateAndPopulateKeyspace(t *testing.T, session gocqlx.Session, keyspa
 	if err != nil {
 		t.Fatal("create table:", err)
 	}
+}
 
-	playlistMetadata := table.Metadata{
+func songTableModel(keyspace string) *table.Table {
+	return table.New(table.Metadata{
+		Name:    fmt.Sprintf("%s.songs", keyspace),
+		Columns: []string{"id", "title", "album", "artist", "tags", "data"},
+		PartKey: []string{"id"},
+	})
+}
+
+func playlistTableModel(keyspace string) *table.Table {
+	return table.New(table.Metadata{
 		Name:    fmt.Sprintf("%s.playlists", keyspace),
 		Columns: []string{"id", "title", "album", "artist", "song_id"},
 		PartKey: []string{"id"},
-		SortKey: []string{"title", "album", "artist", "song_id"},
-	}
-	playlistTable := table.New(playlistMetadata)
+		SortKey: []string{"title", "album", "artist"},
+	})
+}
+
+// This example shows how to use query builders and table models to build
+// queries. It uses "BindStruct" function for parameter binding and "Select"
+// function for loading data to a slice.
+func basicCreateAndPopulateKeyspace(t *testing.T, session gocqlx.Session, keyspace string) {
+	t.Helper()
+
+	createMusicTables(t, session, keyspace)
+	playlistTable := playlistTableModel(keyspace)
 
 	// Insert song using query builder.
 	insertSong := qb.Insert(fmt.Sprintf("%s.songs", keyspace)).
@@ -161,6 +180,106 @@ func basicCreateAndPopulateKeyspace(t *testing.T, session gocqlx.Session, keyspa
 
 	for _, i := range items {
 		t.Logf("%+v", *i)
+	}
+}
+
+// This example shows how to add structs to a batch and execute them together.
+func basicBatchInsertStructs(t *testing.T, session gocqlx.Session, keyspace string) {
+	t.Helper()
+
+	createMusicTables(t, session, keyspace)
+	songTable := songTableModel(keyspace)
+	playlistTable := playlistTableModel(keyspace)
+
+	song := Song{
+		ID:     mustParseUUID("c6f075cb-f98f-4e51-9aa5-9b218ff26ad2"),
+		Title:  "Moonlight Serenade",
+		Album:  "The Essential Glenn Miller",
+		Artist: "Glenn Miller",
+		Tags:   []string{"swing"},
+		Data:   []byte("music"),
+	}
+	playlist := PlaylistItem{
+		ID:     mustParseUUID("7720de96-8984-41a7-a560-91f2398d6ebf"),
+		Title:  song.Title,
+		Album:  song.Album,
+		Artist: song.Artist,
+		SongID: song.ID,
+	}
+
+	// Use a logged batch because these denormalized rows span partitions and
+	// must stay in sync.
+	batch := session.Batch(gocql.LoggedBatch)
+
+	insertSong := songTable.InsertQuery(session)
+	err := batch.BindStruct(insertSong, song)
+	insertSong.Release()
+	if err != nil {
+		t.Fatal("bind song:", err)
+	}
+
+	insertPlaylist := playlistTable.InsertQuery(session)
+	err = batch.BindStruct(insertPlaylist, playlist)
+	insertPlaylist.Release()
+	if err != nil {
+		t.Fatal("bind playlist:", err)
+	}
+
+	if err := session.ExecuteBatch(batch); err != nil {
+		t.Fatal("execute batch:", err)
+	}
+
+	var gotSong Song
+	if err := songTable.GetQuery(session).BindStruct(song).GetRelease(&gotSong); err != nil {
+		t.Fatal("select song:", err)
+	}
+	if diff := cmp.Diff(gotSong, song); diff != "" {
+		t.Fatalf("song mismatch (-got +want):\n%s", diff)
+	}
+
+	var gotPlaylist PlaylistItem
+	if err := playlistTable.GetQuery(session).BindStruct(playlist).GetRelease(&gotPlaylist); err != nil {
+		t.Fatal("select playlist:", err)
+	}
+	if diff := cmp.Diff(gotPlaylist, playlist); diff != "" {
+		t.Fatalf("playlist mismatch (-got +want):\n%s", diff)
+	}
+}
+
+// This example shows how to update a row through a table model.
+func basicUpdateWithTableModel(t *testing.T, session gocqlx.Session, keyspace string) {
+	t.Helper()
+
+	createMusicTables(t, session, keyspace)
+	songTable := songTableModel(keyspace)
+
+	song := Song{
+		ID:     mustParseUUID("5b355d4f-9f91-43b7-83d4-d51d0797cd71"),
+		Title:  "Original title",
+		Album:  "Original album",
+		Artist: "Original artist",
+		Tags:   []string{"demo"},
+		Data:   []byte("music"),
+	}
+	if err := songTable.InsertQuery(session).BindStruct(song).ExecRelease(); err != nil {
+		t.Fatal("insert song:", err)
+	}
+
+	song.Title = "Updated title"
+	song.Album = "Updated album"
+	// The full struct can be bound here: UpdateQuery writes only title and
+	// album and uses id for the WHERE clause because binding follows the
+	// statement's named parameters.
+	if err := songTable.UpdateQuery(session, "title", "album").BindStruct(song).ExecRelease(); err != nil {
+		t.Fatal("update song:", err)
+	}
+
+	var got Song
+	if err := songTable.GetQuery(session).BindStruct(song).GetRelease(&got); err != nil {
+		t.Fatal("select updated song:", err)
+	}
+	if got.Title != song.Title || got.Album != song.Album {
+		t.Fatalf("updated song=%+v expected title=%q album=%q", got, song.Title, song.Album)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an example that binds multiple structs into a gocqlx batch and verifies the complete inserted rows
- add an example that updates a row through a table model
- factor the shared songs/playlists example schema into reusable helpers
- correct the playlist table model clustering key to match the schema, preventing Get, Update, and Delete queries from filtering on the regular `song_id` column

Fixes #256

## Testing
- `go test $(go list ./... | rg -v "/cmd/schemagen$")`
- `make start-scylla && go test -tags all -count=1 -run "^TestExample$" .; make stop-scylla`