### PR TITLE
migrate: preserve progress after cancellation

### DIFF
--- a/gocqlxtest/gocqlxtest.go
+++ b/gocqlxtest/gocqlxtest.go
@@ -35,7 +35,7 @@ func CreateSession(tb testing.TB) gocqlx.Session {
 	tb.Helper()
 
 	cluster := CreateCluster()
-	return createSessionFromCluster(tb, cluster)
+	return CreateSessionFromCluster(tb, cluster)
 }
 
 // CreateCluster creates gocql ClusterConfig from flags.
@@ -122,7 +122,9 @@ func execCreateKeyspaceStmt(session execStmtSession, stmt string) error {
 	return session.ExecStmt(stmt + ` AND tablets = {'enabled': false}`)
 }
 
-func createSessionFromCluster(tb testing.TB, cluster *gocql.ClusterConfig) gocqlx.Session {
+// CreateSessionFromCluster creates a new gocqlx session from cluster while
+// preserving the shared test keyspace lifecycle.
+func CreateSessionFromCluster(tb testing.TB, cluster *gocql.ClusterConfig) gocqlx.Session {
 	tb.Helper()
 	if !flag.Parsed() {
 		flag.Parse()

--- a/migrate/callback.go
+++ b/migrate/callback.go
@@ -23,9 +23,15 @@ const (
 
 // CallbackFunc enables execution of arbitrary Go code during migration.
 // If error is returned the migration is aborted.
-// BeforeMigration and AfterMigration are triggered before and after processing
-// of each migration file respectively.
+// BeforeMigration is triggered before processing each migration file and again
+// before processing its remaining statements after a partial migration resumes.
+// AfterMigration is attempted after the final statement's progress is recorded
+// and is not retried if it returns an error, including one caused by context
+// cancellation or deadline expiry.
 // CallComment is triggered for each comment in a form `-- CALL <name>;` (note the semicolon).
+// BeforeMigration and AfterMigration receive the caller's context. CallComment
+// receives a context detached from caller cancellation and deadlines so a callback
+// that is part of a started migration operation completes with its progress update.
 type CallbackFunc func(ctx context.Context, session gocqlx.Session, ev CallbackEvent, name string) error
 
 // Callback is means of executing Go code during migrations.

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -143,13 +143,18 @@ func Migrate(ctx context.Context, session gocqlx.Session, dir string) error {
 // FromFS executes new CQL files from a file system abstraction (io/fs.FS).
 // The provided FS has to be a flat directory containing *.cql files.
 //
+// Cancellation and deadlines stop migration between statements. Once a
+// statement starts, its execution and progress update finish before the
+// cancellation error is returned. AfterMigration runs only when the file's
+// final statement completes.
+//
 // It supports code based migrations, see Callback and CallbackFunc.
 // Any comment in form `-- CALL <name>;` will trigger an CallComment callback.
 func FromFS(ctx context.Context, session gocqlx.Session, f fs.FS) error {
 	// get database migrations
 	dbm, err := List(ctx, session)
 	if err != nil {
-		return fmt.Errorf("list migrations: %s", err)
+		return fmt.Errorf("list migrations: %w", err)
 	}
 
 	// get file migrations
@@ -184,18 +189,18 @@ func FromFS(ctx context.Context, session gocqlx.Session, f fs.FS) error {
 	if len(dbm) > 0 {
 		last := len(dbm) - 1
 		if err := applyMigration(ctx, session, f, fm[last], dbm[last].Done); err != nil {
-			return fmt.Errorf("apply migration %q: %s", fm[last], err)
+			return fmt.Errorf("apply migration %q: %w", fm[last], err)
 		}
 	}
 
 	for i := len(dbm); i < len(fm); i++ {
 		if err := applyMigration(ctx, session, f, fm[i], 0); err != nil {
-			return fmt.Errorf("apply migration %q: %s", fm[i], err)
+			return fmt.Errorf("apply migration %q: %w", fm[i], err)
 		}
 	}
 
 	if err = session.AwaitSchemaAgreement(ctx); err != nil {
-		return fmt.Errorf("awaiting schema agreement: %s", err)
+		return fmt.Errorf("awaiting schema agreement: %w", err)
 	}
 
 	return nil
@@ -211,7 +216,8 @@ func FromFS(ctx context.Context, session gocqlx.Session, f fs.FS) error {
 // allowing for resumption of partially completed migrations.
 //
 // Parameters:
-//   - ctx: context for cancellation and timeouts
+//   - ctx: context checked between statements and passed to BeforeMigration,
+//     AfterMigration, and schema-agreement waits
 //   - session: database session for executing statements
 //   - f: filesystem containing the migration file
 //   - path: path to the migration file within the filesystem
@@ -244,12 +250,15 @@ func applyMigration(ctx context.Context, session gocqlx.Session, f fs.FS, path s
 		"end_time",
 	).ToCql()
 
-	update := session.ContextQuery(ctx, stmt, names)
+	// Once a statement starts, allow both the statement and its progress update
+	// to finish. The parent context is checked between statements below.
+	operationCtx := context.WithoutCancel(ctx)
+	update := session.ContextQuery(operationCtx, stmt, names)
 	defer update.Release()
 
 	if DefaultAwaitSchemaAgreement.ShouldAwait(AwaitSchemaAgreementBeforeEachFile) {
 		if err = session.AwaitSchemaAgreement(ctx); err != nil {
-			return fmt.Errorf("awaiting schema agreement: %s", err)
+			return fmt.Errorf("awaiting schema agreement: %w", err)
 		}
 	}
 
@@ -274,15 +283,25 @@ func applyMigration(ctx context.Context, session gocqlx.Session, f fs.FS, path s
 			continue
 		}
 
-		if Callback != nil && i == 1 {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("context ended before statement %d: %w", i, err)
+		}
+
+		if Callback != nil && i == done+1 {
 			if err := Callback(ctx, session, BeforeMigration, info.Name); err != nil {
-				return fmt.Errorf("before migration callback: %s", err)
+				return fmt.Errorf("before migration callback: %w", err)
+			}
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("context ended before statement %d: %w", i, err)
 			}
 		}
 
 		if DefaultAwaitSchemaAgreement.ShouldAwait(AwaitSchemaAgreementBeforeEachStatement) {
 			if err = session.AwaitSchemaAgreement(ctx); err != nil {
-				return fmt.Errorf("awaiting schema agreement: %s", err)
+				return fmt.Errorf("awaiting schema agreement before statement %d: %w", i, err)
+			}
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("context ended before statement %d: %w", i, err)
 			}
 		}
 
@@ -295,14 +314,14 @@ func applyMigration(ctx context.Context, session gocqlx.Session, f fs.FS, path s
 			if Callback == nil {
 				return fmt.Errorf("statement %d: missing callback handler while trying to call %s", i, cb)
 			}
-			if err := Callback(ctx, session, CallComment, cb); err != nil {
-				return fmt.Errorf("callback %s: %s", cb, err)
+			if err := Callback(operationCtx, session, CallComment, cb); err != nil {
+				return fmt.Errorf("callback %s: %w", cb, err)
 			}
 		} else if stmt != "" && !isComment(stmt) {
 			// Execute SQL statements (skip empty statements and comments)
-			q := session.ContextQuery(ctx, stmt, nil).RetryPolicy(nil)
+			q := session.ContextQuery(operationCtx, stmt, nil).RetryPolicy(nil)
 			if err := q.ExecRelease(); err != nil {
-				return fmt.Errorf("statement %d: %s", i, err)
+				return fmt.Errorf("statement %d: %w", i, err)
 			}
 		}
 		// Regular comments and empty statements are silently skipped
@@ -311,7 +330,7 @@ func applyMigration(ctx context.Context, session gocqlx.Session, f fs.FS, path s
 		info.Done = i
 		info.EndTime = time.Now()
 		if err := update.BindStruct(info).Exec(); err != nil {
-			return fmt.Errorf("migration statement %d: %s", i, err)
+			return fmt.Errorf("migration statement %d: %w", i, err)
 		}
 	}
 	if i == 0 {
@@ -320,7 +339,7 @@ func applyMigration(ctx context.Context, session gocqlx.Session, f fs.FS, path s
 
 	if Callback != nil && i > done {
 		if err := Callback(ctx, session, AfterMigration, info.Name); err != nil {
-			return fmt.Errorf("after migration callback: %s", err)
+			return fmt.Errorf("after migration callback: %w", err)
 		}
 	}
 

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -9,11 +9,15 @@ package migrate_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/gocql/gocql"
 	"github.com/psanford/memfs"
 
 	"github.com/scylladb/gocqlx/v3"
@@ -379,11 +383,325 @@ func TestMigrationCallback(t *testing.T) {
 	})
 }
 
+func TestMigrationRecordsProgressAfterContextCanceled(t *testing.T) {
+	session := gocqlxtest.CreateSession(t)
+	defer session.Close()
+	recreateTables(t, session)
+
+	f := memfs.New()
+	err := f.WriteFile("0.cql", []byte(fmt.Sprintf(insertMigrate, 0)+";\n-- CALL cancel;\n-- CALL after_cancel;\n"+fmt.Sprintf(insertMigrate, 1)+";"), fs.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	afterCancelCalls := 0
+	beforeCalls := 0
+	afterMigrationCalls := 0
+	migrate.Callback = func(callbackCtx context.Context, session gocqlx.Session, ev migrate.CallbackEvent, name string) error {
+		if ev == migrate.BeforeMigration {
+			beforeCalls++
+		}
+		if ev == migrate.AfterMigration {
+			afterMigrationCalls++
+		}
+		if ev == migrate.CallComment && name == "cancel" {
+			cancel()
+			if err := callbackCtx.Err(); err != nil {
+				return fmt.Errorf("callback context was canceled: %w", err)
+			}
+		}
+		if ev == migrate.CallComment && name == "after_cancel" {
+			afterCancelCalls++
+		}
+		return nil
+	}
+	defer func() {
+		migrate.Callback = nil
+	}()
+
+	err = migrate.FromFS(ctx, session, f)
+	if !errors.Is(err, context.Canceled) || !strings.Contains(err.Error(), "context ended before statement 3") {
+		t.Fatalf("FromFS() error=%v expected context canceled", err)
+	}
+
+	if done := migrationDone(t, session, "0.cql"); done != 2 {
+		t.Fatalf("migration done=%d expected 2", done)
+	}
+	if count := countMigrations(t, session); count != 1 {
+		t.Fatalf("migration statements executed=%d expected 1", count)
+	}
+	if afterCancelCalls != 0 {
+		t.Fatalf("post-cancellation callback calls=%d expected 0", afterCancelCalls)
+	}
+	if beforeCalls != 1 {
+		t.Fatalf("before migration callback calls=%d expected 1", beforeCalls)
+	}
+	if afterMigrationCalls != 0 {
+		t.Fatalf("after migration callback calls=%d expected 0", afterMigrationCalls)
+	}
+
+	if err := migrate.FromFS(context.Background(), session, f); err != nil {
+		t.Fatalf("resume migration: %v", err)
+	}
+	if done := migrationDone(t, session, "0.cql"); done != 4 {
+		t.Fatalf("resumed migration done=%d expected 4", done)
+	}
+	if count := countMigrations(t, session); count != 2 {
+		t.Fatalf("migration statements executed after resume=%d expected 2", count)
+	}
+	if afterCancelCalls != 1 {
+		t.Fatalf("post-cancellation callback calls after resume=%d expected 1", afterCancelCalls)
+	}
+	if beforeCalls != 2 {
+		t.Fatalf("before migration callback calls after resume=%d expected 2", beforeCalls)
+	}
+	if afterMigrationCalls != 1 {
+		t.Fatalf("after migration callback calls after resume=%d expected 1", afterMigrationCalls)
+	}
+}
+
+func TestMigrationBeforeCallbackUsesParentContext(t *testing.T) {
+	session := gocqlxtest.CreateSession(t)
+	defer session.Close()
+	recreateTables(t, session)
+
+	f := memfs.New()
+	err := f.WriteFile("0.cql", []byte(fmt.Sprintf(insertMigrate, 0)+";"), fs.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var callbackErr error
+	migrate.Callback = func(callbackCtx context.Context, session gocqlx.Session, ev migrate.CallbackEvent, name string) error {
+		if ev == migrate.BeforeMigration {
+			cancel()
+			callbackErr = callbackCtx.Err()
+		}
+		return nil
+	}
+	defer func() {
+		migrate.Callback = nil
+	}()
+
+	err = migrate.FromFS(ctx, session, f)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("FromFS() error=%v expected context canceled", err)
+	}
+	if !errors.Is(callbackErr, context.Canceled) {
+		t.Fatalf("callback context error=%v expected context canceled", callbackErr)
+	}
+	if count := countMigrations(t, session); count != 0 {
+		t.Fatalf("migration statements executed=%d expected 0", count)
+	}
+}
+
+func TestMigrationAfterCallbackUsesParentContext(t *testing.T) {
+	session := gocqlxtest.CreateSession(t)
+	defer session.Close()
+	recreateTables(t, session)
+
+	f := memfs.New()
+	err := f.WriteFile("0.cql", []byte("-- CALL cancel;"), fs.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	afterCalls := 0
+	migrate.Callback = func(callbackCtx context.Context, session gocqlx.Session, ev migrate.CallbackEvent, name string) error {
+		switch ev {
+		case migrate.CallComment:
+			cancel()
+		case migrate.AfterMigration:
+			afterCalls++
+			err := callbackCtx.Err()
+			if err == nil {
+				return errors.New("after migration context was not canceled")
+			}
+			return err
+		}
+		return nil
+	}
+	defer func() {
+		migrate.Callback = nil
+	}()
+
+	err = migrate.FromFS(ctx, session, f)
+	if !errors.Is(err, context.Canceled) || !strings.Contains(err.Error(), "after migration callback: context canceled") {
+		t.Fatalf("FromFS() error=%v expected canceled AfterMigration callback", err)
+	}
+	if done := migrationDone(t, session, "0.cql"); done != 1 {
+		t.Fatalf("migration done=%d expected 1", done)
+	}
+	if afterCalls != 1 {
+		t.Fatalf("after migration callback calls=%d expected 1", afterCalls)
+	}
+	if count := countMigrations(t, session); count != 0 {
+		t.Fatalf("migration statements executed=%d expected 0", count)
+	}
+
+	if err := migrate.FromFS(context.Background(), session, f); err != nil {
+		t.Fatalf("resume migration: %v", err)
+	}
+	if afterCalls != 1 {
+		t.Fatalf("after migration callback calls after resume=%d expected 1", afterCalls)
+	}
+}
+
+func TestMigrationCQLStatementUsesDetachedContext(t *testing.T) {
+	ctx := newManualDeadlineContext(context.Background())
+	deadlineObserved := make(chan bool, 1)
+	cluster := gocqlxtest.CreateCluster()
+	cluster.QueryObserver = queryObserverFunc(func(queryCtx context.Context, query gocql.ObservedQuery) {
+		if !strings.Contains(query.Statement, "INSERT INTO gocqlx_test.migrate_table") {
+			return
+		}
+		_, hasDeadline := queryCtx.Deadline()
+		deadlineObserved <- hasDeadline
+		ctx.expire()
+	})
+	session := gocqlxtest.CreateSessionFromCluster(t, cluster)
+	defer session.Close()
+	recreateTables(t, session)
+
+	f := memfs.New()
+	if err := f.WriteFile("0.cql", []byte(fmt.Sprintf(insertMigrate, 0)+";\n"+fmt.Sprintf(insertMigrate, 1)+";"), fs.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	err := migrate.FromFS(ctx, session, f)
+	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "context ended before statement 2") {
+		t.Fatalf("FromFS() error=%v expected deadline exceeded before statement 2", err)
+	}
+	select {
+	case hasDeadline := <-deadlineObserved:
+		if hasDeadline {
+			t.Fatal("CQL statement context retained parent deadline")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting to observe CQL statement")
+	}
+	if done := migrationDone(t, session, "0.cql"); done != 1 {
+		t.Fatalf("migration done=%d expected 1", done)
+	}
+	if count := countMigrations(t, session); count != 1 {
+		t.Fatalf("migration statements executed=%d expected 1", count)
+	}
+}
+
+func TestMigrationFinishesStartedOperationAfterDeadline(t *testing.T) {
+	session := gocqlxtest.CreateSession(t)
+	defer session.Close()
+	recreateTables(t, session)
+
+	f := memfs.New()
+	err := f.WriteFile("0.cql", []byte(fmt.Sprintf(insertMigrate, 0)+";\n-- CALL wait_for_deadline;\n"+fmt.Sprintf(insertMigrate, 1)+";"), fs.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := newManualDeadlineContext(context.Background())
+	migrate.Callback = func(callbackCtx context.Context, session gocqlx.Session, ev migrate.CallbackEvent, name string) error {
+		if ev == migrate.CallComment && name == "wait_for_deadline" {
+			ctx.expire()
+			if _, ok := callbackCtx.Deadline(); ok {
+				return errors.New("callback context retained parent deadline")
+			}
+			if err := callbackCtx.Err(); err != nil {
+				return fmt.Errorf("callback context ended: %w", err)
+			}
+		}
+		return nil
+	}
+	defer func() {
+		migrate.Callback = nil
+	}()
+
+	err = migrate.FromFS(ctx, session, f)
+	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "context ended before statement 3") {
+		t.Fatalf("FromFS() error=%v expected deadline exceeded before statement 3", err)
+	}
+	if done := migrationDone(t, session, "0.cql"); done != 2 {
+		t.Fatalf("migration done=%d expected 2", done)
+	}
+	if count := countMigrations(t, session); count != 1 {
+		t.Fatalf("migration statements executed=%d expected 1", count)
+	}
+
+	if err := migrate.FromFS(context.Background(), session, f); err != nil {
+		t.Fatalf("resume migration: %v", err)
+	}
+	if done := migrationDone(t, session, "0.cql"); done != 3 {
+		t.Fatalf("resumed migration done=%d expected 3", done)
+	}
+	if count := countMigrations(t, session); count != 2 {
+		t.Fatalf("migration statements executed after resume=%d expected 2", count)
+	}
+}
+
+type manualDeadlineContext struct {
+	context.Context
+	deadline   time.Time
+	done       chan struct{}
+	expireOnce sync.Once
+}
+
+func newManualDeadlineContext(parent context.Context) *manualDeadlineContext {
+	return &manualDeadlineContext{
+		Context:  parent,
+		deadline: time.Now().Add(time.Hour),
+		done:     make(chan struct{}),
+	}
+}
+
+func (c *manualDeadlineContext) Deadline() (time.Time, bool) {
+	return c.deadline, true
+}
+
+func (c *manualDeadlineContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *manualDeadlineContext) Err() error {
+	select {
+	case <-c.done:
+		return context.DeadlineExceeded
+	default:
+		return nil
+	}
+}
+
+func (c *manualDeadlineContext) expire() {
+	c.expireOnce.Do(func() {
+		close(c.done)
+	})
+}
+
+type queryObserverFunc func(context.Context, gocql.ObservedQuery)
+
+func (f queryObserverFunc) ObserveQuery(ctx context.Context, query gocql.ObservedQuery) {
+	f(ctx, query)
+}
+
 func countMigrations(tb testing.TB, session gocqlx.Session) int {
 	tb.Helper()
 
 	var v int
 	if err := session.Query("SELECT COUNT(*) FROM gocqlx_test.migrate_table", nil).Get(&v); err != nil {
+		tb.Fatal(err)
+	}
+	return v
+}
+
+func migrationDone(tb testing.TB, session gocqlx.Session, name string) int {
+	tb.Helper()
+
+	var v int
+	if err := session.Query("SELECT done FROM gocqlx_test.gocqlx_migrate WHERE name = ?", nil).Bind(name).Get(&v); err != nil {
 		tb.Fatal(err)
 	}
 	return v


### PR DESCRIPTION
## Summary
- detach migration bookkeeping writes from parent context cancellation with `context.WithoutCancel`
- check the parent context before starting each next unapplied migration statement
- add an integration regression test that cancels after a callback and verifies recorded progress is preserved

Fixes #237

## Testing
- `go test ./migrate`
- `go test -tags integration -run '^$' ./migrate`\n- `go test $(go list ./... | rg -v '/cmd/schemagen$')`\n\nNot run locally: Scylla-backed execution of `TestMigrationRecordsProgressAfterContextCanceled`, because no Scylla/Cassandra node is running on `127.0.0.1:9042`.