### PR TITLE
udt: support automatic UDTs in maps

### DIFF
--- a/batchx.go
+++ b/batchx.go
@@ -65,7 +65,7 @@ func (b *Batch) BindStruct(qry *Queryx, arg interface{}) error {
 	if err != nil {
 		return err
 	}
-	b.Query(qry.Statement(), args...)
+	b.Query(qry.Statement(), udtWrapSlice(qry.Mapper, qry.strict, args)...)
 	return nil
 }
 
@@ -75,7 +75,7 @@ func (b *Batch) Bind(qry *Queryx, args ...interface{}) error {
 	if len(qry.Names) != len(args) {
 		return fmt.Errorf("query requires %d arguments, but %d provided", len(qry.Names), len(args))
 	}
-	b.Query(qry.Statement(), args...)
+	b.Query(qry.Statement(), udtWrapSlice(qry.Mapper, qry.strict, args)...)
 	return nil
 }
 
@@ -86,7 +86,7 @@ func (b *Batch) BindMap(qry *Queryx, arg map[string]interface{}) error {
 	if err != nil {
 		return err
 	}
-	b.Query(qry.Statement(), args...)
+	b.Query(qry.Statement(), udtWrapSlice(qry.Mapper, qry.strict, args)...)
 	return nil
 }
 
@@ -97,7 +97,7 @@ func (b *Batch) BindStructMap(qry *Queryx, arg0 interface{}, arg1 map[string]int
 	if err != nil {
 		return err
 	}
-	b.Query(qry.Statement(), args...)
+	b.Query(qry.Statement(), udtWrapSlice(qry.Mapper, qry.strict, args)...)
 	return nil
 }
 

--- a/iterx_test.go
+++ b/iterx_test.go
@@ -371,6 +371,58 @@ func TestIterxUDT(t *testing.T) {
 	}
 }
 
+func TestIterxUDTCollections(t *testing.T) {
+	type collectionValue struct {
+		gocqlx.UDT
+		UserID string `db:"user_id"`
+	}
+	type collectionKey struct {
+		gocqlx.UDT
+		Code string `db:"code"`
+	}
+
+	session := gocqlxtest.CreateSession(t)
+	defer session.Close()
+
+	for _, stmt := range []string{
+		`CREATE TYPE gocqlx_test.collection_map_value (user_id text)`,
+		`CREATE TYPE gocqlx_test.collection_map_key (code text)`,
+		`CREATE TABLE gocqlx_test.udt_collection_table (
+			id text PRIMARY KEY,
+			by_name map<text, frozen<collection_map_value>>,
+			by_key map<frozen<collection_map_key>, frozen<collection_map_value>>
+		)`,
+	} {
+		if err := session.ExecStmt(stmt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	wantByName := map[string]collectionValue{
+		"one": {UserID: "user-1"},
+	}
+	wantByKey := map[collectionKey]collectionValue{
+		{Code: "one"}: {UserID: "user-1"},
+	}
+	if err := session.Query(`INSERT INTO udt_collection_table (id, by_name, by_key) VALUES (?, ?, ?)`, nil).
+		Bind("one", wantByName, wantByKey).Exec(); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotByName map[string]collectionValue
+	var gotByKey map[collectionKey]collectionValue
+	if err := session.Query(`SELECT by_name, by_key FROM udt_collection_table WHERE id = ?`, nil).
+		Bind("one").Scan(&gotByName, &gotByKey); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(wantByName, gotByName); diff != "" {
+		t.Fatal(diff)
+	}
+	if diff := cmp.Diff(wantByKey, gotByKey); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
 func TestIterxStruct(t *testing.T) {
 	session := gocqlxtest.CreateSession(t)
 	defer session.Close()

--- a/udt.go
+++ b/udt.go
@@ -5,8 +5,13 @@
 package gocqlx
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
+	"math"
 	"reflect"
+	"runtime"
+	"sync"
 
 	"github.com/gocql/gocql"
 	"github.com/scylladb/go-reflectx"
@@ -21,10 +26,17 @@ type UDT interface {
 var (
 	_ gocql.UDTMarshaler   = udt{}
 	_ gocql.UDTUnmarshaler = udt{}
+	_ gocql.Marshaler      = udtCodec{}
+	_ gocql.Unmarshaler    = udtCodec{}
+
+	marshalerInterface    = reflect.TypeOf((*gocql.Marshaler)(nil)).Elem()
+	udtMarshalerInterface = reflect.TypeOf((*gocql.UDTMarshaler)(nil)).Elem()
+	udtTypeCache          sync.Map
 )
 
 type udt struct {
-	field  map[string]reflect.Value
+	fields *reflectx.StructMap
+	mapper *reflectx.Mapper
 	value  reflect.Value
 	strict bool
 }
@@ -32,15 +44,16 @@ type udt struct {
 func makeUDT(value reflect.Value, mapper *reflectx.Mapper, strict bool) udt {
 	return udt{
 		value:  value,
-		field:  mapper.FieldMap(value),
+		fields: mapper.TypeMap(reflect.Indirect(value).Type()),
+		mapper: mapper,
 		strict: strict,
 	}
 }
 
 func (u udt) MarshalUDT(name string, info gocql.TypeInfo) ([]byte, error) {
-	value, ok := u.field[name]
+	value, ok := u.fieldByName(name, true)
 	if ok {
-		return gocql.Marshal(info, value.Interface())
+		return marshalUDTValue(info, value, u.mapper, u.strict)
 	}
 	if !u.strict {
 		return nil, nil
@@ -49,9 +62,9 @@ func (u udt) MarshalUDT(name string, info gocql.TypeInfo) ([]byte, error) {
 }
 
 func (u udt) UnmarshalUDT(name string, info gocql.TypeInfo, data []byte) error {
-	value, ok := u.field[name]
+	value, ok := u.fieldByName(name, false)
 	if ok {
-		return gocql.Unmarshal(info, data, value.Addr().Interface())
+		return unmarshalUDTValue(info, data, value.Addr(), u.mapper, u.strict)
 	}
 	if !u.strict {
 		return nil
@@ -59,20 +72,511 @@ func (u udt) UnmarshalUDT(name string, info gocql.TypeInfo, data []byte) error {
 	return fmt.Errorf("missing name %q in %s", name, u.value.Type())
 }
 
+func (u udt) fieldByName(name string, readOnly bool) (reflect.Value, bool) {
+	value := reflect.Indirect(u.value)
+	field, ok := u.fields.Names[name]
+	if !ok {
+		return reflect.Value{}, false
+	}
+	if !readOnly {
+		return reflectx.FieldByIndexes(value, field.Index), true
+	}
+
+	// FieldByIndexesReadOnly panics on a nil intermediate pointer. Keep this
+	// traversal open-coded so marshaling can return the field's zero value.
+	for _, index := range field.Index {
+		value = reflect.Indirect(value)
+		if !value.IsValid() {
+			return reflect.Zero(field.Field.Type), true
+		}
+		value = value.Field(index)
+	}
+	return value, true
+}
+
+// udtCodec is an internal compatibility layer for mapper-aware UDTs in
+// collections. TODO: replace its custom collection framing when
+// https://github.com/scylladb/gocql/issues/985 provides an upstream hook.
+type udtCodec struct {
+	mapper *reflectx.Mapper
+	value  reflect.Value
+	strict bool
+}
+
+func (u udtCodec) MarshalCQL(info gocql.TypeInfo) ([]byte, error) {
+	return marshalUDTValue(info, u.value, u.mapper, u.strict)
+}
+
+func (u udtCodec) UnmarshalCQL(info gocql.TypeInfo, data []byte) error {
+	return unmarshalUDTValue(info, data, u.value, u.mapper, u.strict)
+}
+
 // udtWrapValue adds UDT wrapper if needed.
 func udtWrapValue(value reflect.Value, mapper *reflectx.Mapper, strict bool) interface{} {
+	if !value.IsValid() {
+		return nil
+	}
+	value = indirectInterface(value)
+	if isNil(value) {
+		return value.Interface()
+	}
 	if value.Type().Implements(autoUDTInterface) {
-		return makeUDT(value, mapper, strict)
+		return udtCodec{value: value, mapper: mapper, strict: strict}
+	}
+	if typeContainsUDT(value.Type()) {
+		return udtCodec{value: value, mapper: mapper, strict: strict}
 	}
 	return value.Interface()
 }
 
 // udtWrapSlice adds UDT wrapper if needed.
 func udtWrapSlice(mapper *reflectx.Mapper, strict bool, v []interface{}) []interface{} {
+	out := make([]interface{}, len(v))
 	for i := range v {
-		if _, ok := v[i].(UDT); ok {
-			v[i] = makeUDT(reflect.ValueOf(v[i]), mapper, strict)
+		out[i] = udtWrapValue(reflect.ValueOf(v[i]), mapper, strict)
+	}
+	return out
+}
+
+func marshalUDTValue(info gocql.TypeInfo, value reflect.Value, mapper *reflectx.Mapper, strict bool) ([]byte, error) {
+	value = indirectInterface(value)
+	if !value.IsValid() || value.Kind() == reflect.Ptr && value.IsNil() {
+		return nil, nil
+	}
+	autoUDT := value.Type().Implements(autoUDTInterface)
+	if value.CanInterface() {
+		v := value.Interface()
+		if _, ok := v.(gocql.Marshaler); ok && (!autoUDT || !hasPromotedCodec(value.Type(), marshalerInterface)) {
+			return gocql.Marshal(info, v)
+		}
+		if info.Type() == gocql.TypeUDT {
+			if _, ok := v.(gocql.UDTMarshaler); ok && (!autoUDT || !hasPromotedCodec(value.Type(), udtMarshalerInterface)) {
+				return gocql.Marshal(info, v)
+			}
 		}
 	}
-	return v
+	if value.Kind() == reflect.Interface && value.IsNil() {
+		return nil, nil
+	}
+	if autoUDT {
+		return gocql.Marshal(info, makeUDT(value, mapper, strict))
+	}
+	if value.Kind() == reflect.Ptr {
+		return marshalUDTValue(info, value.Elem(), mapper, strict)
+	}
+
+	switch info.Type() {
+	case gocql.TypeList, gocql.TypeSet:
+		return marshalUDTCollection(info, value, mapper, strict)
+	case gocql.TypeMap:
+		return marshalUDTMap(info, value, mapper, strict)
+	default:
+		// TODO: add mapper-aware tuple and vector recursion in #395.
+		return gocql.Marshal(info, value.Interface())
+	}
+}
+
+func marshalUDTMap(info gocql.TypeInfo, value reflect.Value, mapper *reflectx.Mapper, strict bool) ([]byte, error) {
+	mapInfo, ok := info.(gocql.CollectionType)
+	if !ok || value.Kind() != reflect.Map {
+		return gocql.Marshal(info, value.Interface())
+	}
+	if value.IsNil() {
+		return nil, nil
+	}
+
+	buf := &bytes.Buffer{}
+	if err := writeCollectionSize(buf, value.Len()); err != nil {
+		return nil, err
+	}
+	for _, key := range value.MapKeys() {
+		data, err := marshalUDTValue(mapInfo.Key, key, mapper, strict)
+		if err != nil {
+			return nil, err
+		}
+		if err := writeCollectionBytes(buf, data); err != nil {
+			return nil, err
+		}
+
+		data, err = marshalUDTValue(mapInfo.Elem, value.MapIndex(key), mapper, strict)
+		if err != nil {
+			return nil, err
+		}
+		if err := writeCollectionBytes(buf, data); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func marshalUDTCollection(info gocql.TypeInfo, value reflect.Value, mapper *reflectx.Mapper, strict bool) ([]byte, error) {
+	collectionInfo, ok := info.(gocql.CollectionType)
+	if !ok {
+		return gocql.Marshal(info, value.Interface())
+	}
+
+	var items []reflect.Value
+	switch value.Kind() {
+	case reflect.Slice:
+		if value.IsNil() {
+			return nil, nil
+		}
+		items = make([]reflect.Value, value.Len())
+		for i := range items {
+			items[i] = value.Index(i)
+		}
+	case reflect.Array:
+		items = make([]reflect.Value, value.Len())
+		for i := range items {
+			items[i] = value.Index(i)
+		}
+	case reflect.Map:
+		if value.Type().Elem().Kind() != reflect.Struct || value.Type().Elem().NumField() != 0 {
+			return gocql.Marshal(info, value.Interface())
+		}
+		items = value.MapKeys()
+	default:
+		return gocql.Marshal(info, value.Interface())
+	}
+
+	buf := &bytes.Buffer{}
+	if err := writeCollectionSize(buf, len(items)); err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		data, err := marshalUDTValue(collectionInfo.Elem, item, mapper, strict)
+		if err != nil {
+			return nil, err
+		}
+		if err := writeCollectionBytes(buf, data); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func unmarshalUDTValue(info gocql.TypeInfo, data []byte, value reflect.Value, mapper *reflectx.Mapper, strict bool) error {
+	value = indirectInterface(value)
+	if !value.IsValid() {
+		return fmt.Errorf("cannot unmarshal %s into an invalid value", info)
+	}
+	autoUDT := value.Type().Implements(autoUDTInterface)
+	if value.CanInterface() {
+		v := value.Interface()
+		if _, ok := v.(gocql.Unmarshaler); ok && (!autoUDT || !hasPromotedCodec(value.Type(), unmarshallerInterface)) {
+			return gocql.Unmarshal(info, data, v)
+		}
+		if info.Type() == gocql.TypeUDT {
+			if _, ok := v.(gocql.UDTUnmarshaler); ok && (!autoUDT || !hasPromotedCodec(value.Type(), udtUnmarshallerInterface)) {
+				return gocql.Unmarshal(info, data, v)
+			}
+		}
+	}
+	if autoUDT {
+		// TODO: remove this automatic-UDT workaround after
+		// https://github.com/scylladb/gocql/issues/986 is fixed upstream.
+		if data == nil {
+			return zeroUDTValue(value)
+		}
+		return gocql.Unmarshal(info, data, makeUDT(value, mapper, strict))
+	}
+	if value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			if data == nil {
+				return nil
+			}
+			value.Set(reflect.New(value.Type().Elem()))
+		}
+		if value.Elem().Kind() == reflect.Ptr {
+			if data == nil {
+				value.Elem().Set(reflect.Zero(value.Type().Elem()))
+				return nil
+			}
+			if value.Elem().IsNil() {
+				value.Elem().Set(reflect.New(value.Type().Elem().Elem()))
+			}
+			return unmarshalUDTValue(info, data, value.Elem(), mapper, strict)
+		}
+		value = value.Elem()
+	}
+
+	switch info.Type() {
+	case gocql.TypeList, gocql.TypeSet:
+		if !value.CanSet() {
+			return fmt.Errorf("cannot unmarshal %s into non-pointer %s", info, value.Type())
+		}
+		return unmarshalUDTCollection(info, data, value, mapper, strict)
+	case gocql.TypeMap:
+		if !value.CanSet() {
+			return fmt.Errorf("cannot unmarshal %s into non-pointer %s", info, value.Type())
+		}
+		return unmarshalUDTMap(info, data, value, mapper, strict)
+	default:
+		if value.CanAddr() {
+			return gocql.Unmarshal(info, data, value.Addr().Interface())
+		}
+		return gocql.Unmarshal(info, data, value.Interface())
+	}
+}
+
+func zeroUDTValue(value reflect.Value) error {
+	if value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return nil
+		}
+		value = value.Elem()
+	}
+	if !value.CanSet() {
+		return fmt.Errorf("cannot zero %s", value.Type())
+	}
+	value.Set(reflect.Zero(value.Type()))
+	return nil
+}
+
+func unmarshalUDTCollection(info gocql.TypeInfo, data []byte, value reflect.Value, mapper *reflectx.Mapper, strict bool) error {
+	collectionInfo, ok := info.(gocql.CollectionType)
+	if !ok {
+		return unmarshalUDTFallback(info, data, value)
+	}
+
+	kind := value.Kind()
+	isMapSet := kind == reflect.Map && value.Type().Elem().Kind() == reflect.Struct && value.Type().Elem().NumField() == 0
+	if kind != reflect.Slice && kind != reflect.Array && !isMapSet {
+		return unmarshalUDTFallback(info, data, value)
+	}
+	if data == nil {
+		if kind == reflect.Array {
+			return unmarshalUDTFallback(info, data, value)
+		}
+		value.Set(reflect.Zero(value.Type()))
+		return nil
+	}
+
+	n, rest, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return fmt.Errorf("negative collection size %d", n)
+	}
+
+	switch {
+	case kind == reflect.Array:
+		if value.Len() != n {
+			return fmt.Errorf("cannot unmarshal collection of length %d into %s", n, value.Type())
+		}
+	case kind == reflect.Slice:
+		value.Set(reflect.MakeSlice(value.Type(), n, n))
+	case isMapSet:
+		value.Set(reflect.MakeMapWithSize(value.Type(), n))
+	}
+
+	for i := 0; i < n; i++ {
+		itemData, next, err := readCollectionBytes(rest)
+		if err != nil {
+			return err
+		}
+		rest = next
+
+		if isMapSet {
+			key := reflect.New(value.Type().Key())
+			if err := unmarshalUDTValue(collectionInfo.Elem, itemData, key, mapper, strict); err != nil {
+				return err
+			}
+			value.SetMapIndex(key.Elem(), reflect.Zero(value.Type().Elem()))
+			continue
+		}
+
+		if err := unmarshalUDTValue(collectionInfo.Elem, itemData, value.Index(i).Addr(), mapper, strict); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func unmarshalUDTFallback(info gocql.TypeInfo, data []byte, value reflect.Value) error {
+	if value.CanAddr() {
+		return gocql.Unmarshal(info, data, value.Addr().Interface())
+	}
+	return gocql.Unmarshal(info, data, value.Interface())
+}
+
+func unmarshalUDTMap(info gocql.TypeInfo, data []byte, value reflect.Value, mapper *reflectx.Mapper, strict bool) error {
+	mapInfo, ok := info.(gocql.CollectionType)
+	if !ok || value.Kind() != reflect.Map {
+		return unmarshalUDTFallback(info, data, value)
+	}
+	if data == nil {
+		value.Set(reflect.Zero(value.Type()))
+		return nil
+	}
+
+	n, rest, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return fmt.Errorf("negative map size %d", n)
+	}
+	value.Set(reflect.MakeMapWithSize(value.Type(), n))
+	for i := 0; i < n; i++ {
+		keyData, next, err := readCollectionBytes(rest)
+		if err != nil {
+			return err
+		}
+		rest = next
+		key := reflect.New(value.Type().Key())
+		if err := unmarshalUDTValue(mapInfo.Key, keyData, key, mapper, strict); err != nil {
+			return err
+		}
+
+		valueData, next, err := readCollectionBytes(rest)
+		if err != nil {
+			return err
+		}
+		rest = next
+		item := reflect.New(value.Type().Elem())
+		if err := unmarshalUDTValue(mapInfo.Elem, valueData, item, mapper, strict); err != nil {
+			return err
+		}
+		value.SetMapIndex(key.Elem(), item.Elem())
+	}
+	return nil
+}
+
+func writeCollectionBytes(buf *bytes.Buffer, data []byte) error {
+	if data == nil {
+		return writeCollectionSize(buf, -1)
+	}
+	if err := writeCollectionSize(buf, len(data)); err != nil {
+		return err
+	}
+	_, err := buf.Write(data)
+	return err
+}
+
+func writeCollectionSize(buf *bytes.Buffer, size int) error {
+	if size > math.MaxInt32 {
+		return fmt.Errorf("collection too large")
+	}
+	var data [4]byte
+	binary.BigEndian.PutUint32(data[:], uint32(int32(size)))
+	_, err := buf.Write(data[:])
+	return err
+}
+
+func readCollectionBytes(data []byte) (value, rest []byte, err error) {
+	size, rest, err := readCollectionSize(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	if size < 0 {
+		return nil, rest, nil
+	}
+	if len(rest) < size {
+		return nil, nil, fmt.Errorf("unexpected end of collection data")
+	}
+	return rest[:size], rest[size:], nil
+}
+
+func readCollectionSize(data []byte) (size int, rest []byte, err error) {
+	if len(data) < 4 {
+		return 0, nil, fmt.Errorf("unexpected end of collection data")
+	}
+	return int(int32(binary.BigEndian.Uint32(data[:4]))), data[4:], nil
+}
+
+func containsUDT(t reflect.Type, seen map[reflect.Type]bool) bool {
+	if t.Implements(autoUDTInterface) {
+		return true
+	}
+	if seen[t] {
+		return false
+	}
+	seen[t] = true
+	switch t.Kind() {
+	case reflect.Ptr, reflect.Slice, reflect.Array:
+		return containsUDT(t.Elem(), seen)
+	case reflect.Map:
+		return containsUDT(t.Key(), seen) || containsUDT(t.Elem(), seen)
+	case reflect.Interface:
+		// The dynamic value may be an automatic UDT. Use the mapper-aware
+		// collection codec because the interface's method set cannot tell us.
+		return true
+	}
+	// Struct fields are intentionally not traversed. Mapper-aware UDT behavior
+	// requires the struct itself to implement the UDT marker contract.
+	return false
+}
+
+func typeContainsUDT(t reflect.Type) bool {
+	if cached, ok := udtTypeCache.Load(t); ok {
+		return cached.(bool)
+	}
+	result := containsUDT(t, make(map[reflect.Type]bool))
+	udtTypeCache.Store(t, result)
+	return result
+}
+
+// hasPromotedCodec reports whether the codec implemented by t is promoted from
+// an anonymous field. Automatic UDT mapping takes precedence in that case so
+// an embedded field's codec cannot accidentally serialize the whole outer UDT.
+func hasPromotedCodec(t, codec reflect.Type) bool {
+	includePointerMethods := t.Kind() == reflect.Ptr
+	methodName := codec.Method(0).Name
+	method, ok := t.MethodByName(methodName)
+	if !ok || !isAutogeneratedMethod(method) {
+		return false
+	}
+	if includePointerMethods {
+		t = t.Elem()
+		// A value-receiver method also has an autogenerated wrapper in the
+		// pointer method set. Check the value method before treating that
+		// wrapper as promotion.
+		if method, ok := t.MethodByName(methodName); ok && !isAutogeneratedMethod(method) {
+			return false
+		}
+	}
+	if t.Kind() != reflect.Struct {
+		return false
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if !field.Anonymous {
+			continue
+		}
+		if field.Type.Implements(codec) {
+			return true
+		}
+		if includePointerMethods && field.Type.Kind() != reflect.Ptr && reflect.PointerTo(field.Type).Implements(codec) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAutogeneratedMethod(method reflect.Method) bool {
+	fn := runtime.FuncForPC(method.Func.Pointer())
+	if fn == nil {
+		return false
+	}
+	file, _ := fn.FileLine(fn.Entry())
+	return file == "<autogenerated>"
+}
+
+func indirectInterface(value reflect.Value) reflect.Value {
+	for value.IsValid() && value.Kind() == reflect.Interface && !value.IsNil() {
+		value = value.Elem()
+	}
+	return value
+}
+
+func isNil(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }

--- a/udt_test.go
+++ b/udt_test.go
@@ -1,0 +1,925 @@
+// Copyright (C) 2017 ScyllaDB
+// Use of this source code is governed by a ALv2-style
+// license that can be found in the LICENSE file.
+
+package gocqlx
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/google/go-cmp/cmp"
+)
+
+type collectionUDT struct {
+	UDT
+	UserID string `db:"user_id"`
+}
+
+type collectionUDTKey struct {
+	UDT
+	Code string `db:"code"`
+}
+
+type customMarshalerUDT struct {
+	UDT
+}
+
+type customUDTCodec struct {
+	UDT
+}
+
+type promotedScalarCodec struct{}
+
+type promotedScalarCodecUDT struct {
+	UDT
+	promotedScalarCodec
+	Value string `db:"value"`
+}
+
+type promotedScalarPointerCodecUDT struct {
+	UDT
+	*promotedScalarCodec
+	Value string `db:"value"`
+}
+
+type promotedUDTCodec struct{}
+
+type promotedUDTCodecUDT struct {
+	UDT
+	promotedUDTCodec
+	Value string `db:"value"`
+}
+
+type explicitScalarCodecUDT struct {
+	UDT
+	promotedScalarCodec
+	Value string `db:"value"`
+}
+
+type nilMarshalerUDTMap map[string]collectionUDT
+
+type nilUDTMarshalerMap map[string]collectionUDT
+
+var (
+	errCustomMarshalerUDT  = errors.New("custom UDT marshaler called")
+	errCustomUDTCodec      = errors.New("custom UDT codec called")
+	errExplicitScalarCodec = errors.New("explicit scalar codec called")
+)
+
+func (customMarshalerUDT) MarshalCQL(gocql.TypeInfo) ([]byte, error) {
+	return nil, errCustomMarshalerUDT
+}
+
+func (nilMarshalerUDTMap) MarshalCQL(gocql.TypeInfo) ([]byte, error) {
+	return nil, errCustomMarshalerUDT
+}
+
+func (nilUDTMarshalerMap) MarshalUDT(string, gocql.TypeInfo) ([]byte, error) {
+	return nil, errCustomUDTCodec
+}
+
+func (customUDTCodec) MarshalUDT(string, gocql.TypeInfo) ([]byte, error) {
+	return nil, errCustomUDTCodec
+}
+
+func (*customUDTCodec) UnmarshalUDT(string, gocql.TypeInfo, []byte) error {
+	return errCustomUDTCodec
+}
+
+func (promotedScalarCodec) MarshalCQL(gocql.TypeInfo) ([]byte, error) {
+	return nil, errCustomMarshalerUDT
+}
+
+func (*promotedScalarCodec) UnmarshalCQL(gocql.TypeInfo, []byte) error {
+	return errCustomMarshalerUDT
+}
+
+func (promotedUDTCodec) MarshalUDT(string, gocql.TypeInfo) ([]byte, error) {
+	return nil, errCustomUDTCodec
+}
+
+func (*promotedUDTCodec) UnmarshalUDT(string, gocql.TypeInfo, []byte) error {
+	return errCustomUDTCodec
+}
+
+func (explicitScalarCodecUDT) MarshalCQL(gocql.TypeInfo) ([]byte, error) {
+	return nil, errExplicitScalarCodec
+}
+
+func (*explicitScalarCodecUDT) UnmarshalCQL(gocql.TypeInfo, []byte) error {
+	return errExplicitScalarCodec
+}
+
+func TestUDTInMaps(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "collection_udt", "",
+		gocql.UDTField{Name: "user_id", Type: textType},
+	)
+	keyType := gocql.NewUDTType(4, "collection_udt_key", "",
+		gocql.UDTField{Name: "code", Type: textType},
+	)
+
+	tests := []struct {
+		name  string
+		info  gocql.TypeInfo
+		value interface{}
+		new   func() interface{}
+	}{
+		{
+			name: "map values",
+			info: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType),
+			value: map[string]collectionUDT{
+				"one": {UserID: "user-1"},
+			},
+			new: func() interface{} { return new(map[string]collectionUDT) },
+		},
+		{
+			name: "map pointer values",
+			info: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType),
+			value: map[string]*collectionUDT{
+				"one": {UserID: "user-1"},
+			},
+			new: func() interface{} { return new(map[string]*collectionUDT) },
+		},
+		{
+			name:  "empty map",
+			info:  gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType),
+			value: map[string]collectionUDT{},
+			new:   func() interface{} { return new(map[string]collectionUDT) },
+		},
+		{
+			name:  "nil map",
+			info:  gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType),
+			value: map[string]collectionUDT(nil),
+			new:   func() interface{} { return new(map[string]collectionUDT) },
+		},
+		{
+			name: "null map value",
+			info: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType),
+			value: map[string]*collectionUDT{
+				"one": nil,
+			},
+			new: func() interface{} { return new(map[string]*collectionUDT) },
+		},
+		{
+			name: "map keys",
+			info: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), keyType, valueType),
+			value: map[collectionUDTKey]collectionUDT{
+				{Code: "one"}: {UserID: "user-1"},
+			},
+			new: func() interface{} { return new(map[collectionUDTKey]collectionUDT) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapped := udtWrapValue(reflect.ValueOf(tt.value), DefaultMapper, false)
+			data, err := gocql.Marshal(tt.info, wrapped)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := tt.new()
+			wrapped = udtWrapValue(reflect.ValueOf(got), DefaultMapper, false)
+			if err := gocql.Unmarshal(tt.info, data, wrapped); err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tt.value, reflect.ValueOf(got).Elem().Interface(), cmp.AllowUnexported(collectionUDT{}, collectionUDTKey{})); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestBatchWrapsUDTMaps(t *testing.T) {
+	query := Query(&gocql.Query{}, []string{"value"})
+	batch := &Batch{Batch: &gocql.Batch{}}
+	value := map[string]collectionUDT{"one": {UserID: "user-1"}}
+
+	if err := batch.Bind(query, value); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := batch.Entries[0].Args[0].(udtCodec); !ok {
+		t.Fatalf("batch argument was not wrapped: %T", batch.Entries[0].Args[0])
+	}
+}
+
+func TestBatchBindDoesNotMutateArgs(t *testing.T) {
+	query := Query(&gocql.Query{}, []string{"value"})
+	batch := &Batch{Batch: &gocql.Batch{}}
+	value := map[string]collectionUDT{"one": {UserID: "user-1"}}
+	args := []interface{}{value}
+
+	if err := batch.Bind(query, args...); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := args[0].(map[string]collectionUDT); !ok {
+		t.Fatalf("caller argument was replaced: %T", args[0])
+	}
+	if _, ok := batch.Entries[0].Args[0].(udtCodec); !ok {
+		t.Fatalf("batch argument was not wrapped: %T", batch.Entries[0].Args[0])
+	}
+}
+
+func TestUDTWrapValueLeavesConcreteNonUDTValuesUnwrapped(t *testing.T) {
+	tests := []interface{}{
+		map[string]string{"one": "value"},
+		[]int{1},
+		time.Unix(1, 0),
+	}
+
+	for _, value := range tests {
+		wrapped := udtWrapValue(reflect.ValueOf(value), DefaultMapper, false)
+		if _, ok := wrapped.(udtCodec); ok {
+			t.Fatalf("non-UDT value was wrapped: %T", value)
+		}
+	}
+}
+
+func TestUDTCollectionFramingMatchesGocql(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	intType := gocql.NewNativeType(4, gocql.TypeInt)
+
+	tests := []struct {
+		name     string
+		info     gocql.TypeInfo
+		upstream interface{}
+		wrapped  interface{}
+	}{
+		{
+			name:     "map",
+			info:     gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, textType),
+			upstream: map[string]string{"one": "value"},
+			wrapped:  map[string]interface{}{"one": "value"},
+		},
+		{
+			name:     "list",
+			info:     gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil, intType),
+			upstream: []int{1},
+			wrapped:  []interface{}{1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want, err := gocql.Marshal(tt.info, tt.upstream)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := gocql.Marshal(tt.info, udtWrapValue(reflect.ValueOf(tt.wrapped), DefaultMapper, false))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestUDTCollectionTypedNilMatchesGocql(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	setType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeSet), nil, textType)
+	mapType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, textType)
+
+	tests := []struct {
+		name  string
+		info  gocql.TypeInfo
+		value []interface{}
+	}{
+		{
+			name:  "wrong map type",
+			info:  gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil, textType),
+			value: []interface{}{map[string]string(nil)},
+		},
+		{
+			name:  "wrong slice type",
+			info:  gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil, textType),
+			value: []interface{}{[]string(nil)},
+		},
+		{
+			name:  "nil map set is empty",
+			info:  gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil, setType),
+			value: []interface{}{map[string]struct{}(nil)},
+		},
+		{
+			name:  "nil map is null",
+			info:  gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil, mapType),
+			value: []interface{}{map[string]string(nil)},
+		},
+		{
+			name: "nil slice is null",
+			info: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil,
+				gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil, textType)),
+			value: []interface{}{[]string(nil)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want, wantErr := gocql.Marshal(tt.info, tt.value)
+			got, gotErr := gocql.Marshal(tt.info, udtWrapValue(reflect.ValueOf(tt.value), DefaultMapper, false))
+			if (wantErr == nil) != (gotErr == nil) {
+				t.Fatalf("error mismatch: gocql=%v wrapped=%v", wantErr, gotErr)
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestUDTInterfaceMapValuesMarshal(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "collection_udt", "",
+		gocql.UDTField{Name: "user_id", Type: textType},
+	)
+	mapType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType)
+	value := map[string]UDT{"one": collectionUDT{UserID: "user-1"}}
+
+	data, err := gocql.Marshal(mapType, udtWrapValue(reflect.ValueOf(value), DefaultMapper, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]collectionUDT
+	if err := gocql.Unmarshal(mapType, data, udtWrapValue(reflect.ValueOf(&got), DefaultMapper, false)); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]collectionUDT{"one": {UserID: "user-1"}}
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(collectionUDT{})); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestUDTEmptyInterfaceCollectionValuesMarshal(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "collection_udt", "",
+		gocql.UDTField{Name: "user_id", Type: textType},
+	)
+
+	tests := []struct {
+		name  string
+		info  gocql.TypeInfo
+		value interface{}
+		want  interface{}
+		new   func() interface{}
+	}{
+		{
+			name: "map values",
+			info: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType),
+			value: map[string]interface{}{
+				"one": collectionUDT{UserID: "user-1"},
+			},
+			want: map[string]collectionUDT{
+				"one": {UserID: "user-1"},
+			},
+			new: func() interface{} { return new(map[string]collectionUDT) },
+		},
+		{
+			name: "slice values",
+			info: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil, valueType),
+			value: []interface{}{
+				collectionUDT{UserID: "user-1"},
+			},
+			want: []collectionUDT{
+				{UserID: "user-1"},
+			},
+			new: func() interface{} { return new([]collectionUDT) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapped := udtWrapValue(reflect.ValueOf(tt.value), DefaultMapper, false)
+			if _, ok := wrapped.(udtCodec); !ok {
+				t.Fatalf("collection was not wrapped: %T", wrapped)
+			}
+			data, err := gocql.Marshal(tt.info, wrapped)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := tt.new()
+			if err := gocql.Unmarshal(tt.info, data, udtWrapValue(reflect.ValueOf(got), DefaultMapper, false)); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.want, reflect.ValueOf(got).Elem().Interface(), cmp.AllowUnexported(collectionUDT{})); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestUDTMapValuesWithNilFieldsMarshal(t *testing.T) {
+	type nullableUDT struct {
+		UDT
+		Optional *string           `db:"optional"`
+		Labels   map[string]string `db:"labels"`
+	}
+
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	labelsType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, textType)
+	valueType := gocql.NewUDTType(4, "nullable_udt", "",
+		gocql.UDTField{Name: "optional", Type: textType},
+		gocql.UDTField{Name: "labels", Type: labelsType},
+	)
+	mapType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType)
+	value := map[string]nullableUDT{"one": {}}
+
+	data, err := gocql.Marshal(mapType, udtWrapValue(reflect.ValueOf(value), DefaultMapper, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]nullableUDT
+	if err := gocql.Unmarshal(mapType, data, udtWrapValue(reflect.ValueOf(&got), DefaultMapper, false)); err != nil {
+		t.Fatal(err)
+	}
+	if got["one"].Optional != nil || got["one"].Labels != nil {
+		t.Fatalf("nil fields were not preserved: %#v", got["one"])
+	}
+}
+
+func TestUDTSliceMarshalPreservesNilFields(t *testing.T) {
+	type nullableUDT struct {
+		UDT
+		Optional *string           `db:"optional"`
+		Labels   map[string]string `db:"labels"`
+	}
+
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	labelsType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, textType)
+	valueType := gocql.NewUDTType(4, "nullable_udt", "",
+		gocql.UDTField{Name: "optional", Type: textType},
+		gocql.UDTField{Name: "labels", Type: labelsType},
+	)
+	listType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil, valueType)
+	value := []nullableUDT{{}}
+
+	if _, err := gocql.Marshal(listType, udtWrapValue(reflect.ValueOf(value), DefaultMapper, false)); err != nil {
+		t.Fatal(err)
+	}
+	if value[0].Optional != nil || value[0].Labels != nil {
+		t.Fatalf("marshal mutated input: %#v", value[0])
+	}
+}
+
+func TestUDTMapStrictMode(t *testing.T) {
+	type incompleteUDT struct {
+		UDT
+	}
+
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "collection_udt", "",
+		gocql.UDTField{Name: "user_id", Type: textType},
+	)
+	mapType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType)
+	value := map[string]incompleteUDT{"one": {}}
+
+	_, err := gocql.Marshal(mapType, udtWrapValue(reflect.ValueOf(value), DefaultMapper, true))
+	if err == nil {
+		t.Fatal("expected missing UDT field error")
+	}
+
+	data, err := gocql.Marshal(mapType, udtWrapValue(reflect.ValueOf(map[string]collectionUDT{
+		"one": {UserID: "user-1"},
+	}), DefaultMapper, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]incompleteUDT
+	if err := gocql.Unmarshal(mapType, data, udtWrapValue(reflect.ValueOf(&got), DefaultMapper, true)); err == nil {
+		t.Fatal("expected missing UDT field error while unmarshaling")
+	}
+}
+
+func TestUDTWithMapField(t *testing.T) {
+	type outerUDT struct {
+		UDT
+		ByName map[string]collectionUDT `db:"by_name"`
+	}
+
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "collection_udt", "",
+		gocql.UDTField{Name: "user_id", Type: textType},
+	)
+	mapType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType)
+	outerType := gocql.NewUDTType(4, "outer_udt", "",
+		gocql.UDTField{Name: "by_name", Type: mapType},
+	)
+
+	want := outerUDT{ByName: map[string]collectionUDT{
+		"one": {UserID: "user-1"},
+	}}
+	data, err := gocql.Marshal(outerType, makeUDT(reflect.ValueOf(want), DefaultMapper, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got outerUDT
+	if err := gocql.Unmarshal(outerType, data, makeUDT(reflect.ValueOf(&got), DefaultMapper, false)); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(collectionUDT{})); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestUDTInNestedCollections(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "collection_udt", "",
+		gocql.UDTField{Name: "user_id", Type: textType},
+	)
+	keyType := gocql.NewUDTType(4, "collection_udt_key", "",
+		gocql.UDTField{Name: "code", Type: textType},
+	)
+	mapType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType)
+	listType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil, valueType)
+
+	tests := []struct {
+		name  string
+		info  gocql.TypeInfo
+		value interface{}
+		new   func() interface{}
+	}{
+		{
+			name: "map list values",
+			info: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, listType),
+			value: map[string][]collectionUDT{
+				"one": {{UserID: "user-1"}},
+			},
+			new: func() interface{} { return new(map[string][]collectionUDT) },
+		},
+		{
+			name: "map array values",
+			info: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, listType),
+			value: map[string][1]collectionUDT{
+				"one": {{UserID: "user-1"}},
+			},
+			new: func() interface{} { return new(map[string][1]collectionUDT) },
+		},
+		{
+			name: "list map values",
+			info: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil, mapType),
+			value: []map[string]collectionUDT{
+				{"one": {UserID: "user-1"}},
+			},
+			new: func() interface{} { return new([]map[string]collectionUDT) },
+		},
+		{
+			name: "set values",
+			info: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeSet), nil, valueType),
+			value: []collectionUDT{
+				{UserID: "user-1"},
+			},
+			new: func() interface{} { return new([]collectionUDT) },
+		},
+		{
+			name: "set map values",
+			info: gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeSet), nil, keyType),
+			value: map[collectionUDTKey]struct{}{
+				{Code: "one"}: {},
+			},
+			new: func() interface{} { return new(map[collectionUDTKey]struct{}) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := gocql.Marshal(tt.info, udtWrapValue(reflect.ValueOf(tt.value), DefaultMapper, false))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := tt.new()
+			if err := gocql.Unmarshal(tt.info, data, udtWrapValue(reflect.ValueOf(got), DefaultMapper, false)); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.value, reflect.ValueOf(got).Elem().Interface(), cmp.AllowUnexported(collectionUDT{}, collectionUDTKey{})); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestUDTNullNestedValueClearsDestination(t *testing.T) {
+	type outerUDT struct {
+		UDT
+		Nested collectionUDT `db:"nested"`
+	}
+
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	nestedType := gocql.NewUDTType(4, "collection_udt", "",
+		gocql.UDTField{Name: "user_id", Type: textType},
+	)
+	outerType := gocql.NewUDTType(4, "outer_udt", "",
+		gocql.UDTField{Name: "nested", Type: nestedType},
+	)
+
+	got := outerUDT{Nested: collectionUDT{UserID: "stale"}}
+	nullNestedUDT := []byte{0xff, 0xff, 0xff, 0xff}
+	if err := gocql.Unmarshal(outerType, nullNestedUDT, makeUDT(reflect.ValueOf(&got), DefaultMapper, false)); err != nil {
+		t.Fatal(err)
+	}
+	if got.Nested.UserID != "" {
+		t.Fatalf("null nested UDT retained %q", got.Nested.UserID)
+	}
+}
+
+func TestUDTNullTopLevelValueClearsDestination(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "collection_udt", "",
+		gocql.UDTField{Name: "user_id", Type: textType},
+	)
+
+	got := collectionUDT{UserID: "stale"}
+	if err := gocql.Unmarshal(valueType, nil, udtWrapValue(reflect.ValueOf(&got), DefaultMapper, false)); err != nil {
+		t.Fatal(err)
+	}
+	if got.UserID != "" {
+		t.Fatalf("null UDT retained %q", got.UserID)
+	}
+}
+
+func TestUDTWrapValueTypedNil(t *testing.T) {
+	var value *collectionUDT
+	wrapped := udtWrapValue(reflect.ValueOf(value), DefaultMapper, false)
+	if got, ok := wrapped.(*collectionUDT); !ok || got != nil {
+		t.Fatalf("typed nil changed: %#v", wrapped)
+	}
+}
+
+func TestUDTCustomMarshalerPrecedence(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "custom_udt", "",
+		gocql.UDTField{Name: "value", Type: textType},
+	)
+	mapType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType)
+	value := map[string]customMarshalerUDT{"one": {}}
+
+	_, err := gocql.Marshal(mapType, udtWrapValue(reflect.ValueOf(value), DefaultMapper, false))
+	if !errors.Is(err, errCustomMarshalerUDT) {
+		t.Fatalf("custom marshaler was bypassed: %v", err)
+	}
+}
+
+func TestUDTNilCollectionCustomCodecPrecedence(t *testing.T) {
+	type marshalerOuterUDT struct {
+		UDT
+		Value nilMarshalerUDTMap `db:"value"`
+	}
+	type udtMarshalerOuterUDT struct {
+		UDT
+		Value nilUDTMarshalerMap `db:"value"`
+	}
+
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "custom_udt", "",
+		gocql.UDTField{Name: "value", Type: textType},
+	)
+	mapType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType)
+	mapOuterType := gocql.NewUDTType(4, "outer_udt", "",
+		gocql.UDTField{Name: "value", Type: mapType},
+	)
+	udtOuterType := gocql.NewUDTType(4, "outer_udt", "",
+		gocql.UDTField{Name: "value", Type: valueType},
+	)
+
+	tests := []struct {
+		name  string
+		info  gocql.TypeInfo
+		value interface{}
+		want  error
+	}{
+		{
+			name:  "Marshaler",
+			info:  mapOuterType,
+			value: marshalerOuterUDT{},
+			want:  errCustomMarshalerUDT,
+		},
+		{
+			name:  "UDTMarshaler",
+			info:  udtOuterType,
+			value: udtMarshalerOuterUDT{},
+			want:  errCustomUDTCodec,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := gocql.Marshal(tt.info, makeUDT(reflect.ValueOf(tt.value), DefaultMapper, false))
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("custom codec was bypassed: %v", err)
+			}
+		})
+	}
+}
+
+func TestUDTNilPointerCustomCodecIsNull(t *testing.T) {
+	valueType := gocql.NewUDTType(4, "custom_udt", "")
+	data, err := marshalUDTValue(valueType, reflect.ValueOf((*customMarshalerUDT)(nil)), DefaultMapper, false)
+	if err != nil {
+		t.Fatalf("nil pointer invoked custom codec: %v", err)
+	}
+	if data != nil {
+		t.Fatalf("nil pointer marshaled as %v", data)
+	}
+}
+
+func TestUDTCustomCodecPrecedence(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "custom_udt", "",
+		gocql.UDTField{Name: "user_id", Type: textType},
+	)
+	mapType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType)
+
+	value := map[string]customUDTCodec{"one": {}}
+	_, err := gocql.Marshal(mapType, udtWrapValue(reflect.ValueOf(value), DefaultMapper, false))
+	if !errors.Is(err, errCustomUDTCodec) {
+		t.Fatalf("custom UDT marshaler was bypassed: %v", err)
+	}
+
+	data, err := gocql.Marshal(mapType, udtWrapValue(reflect.ValueOf(map[string]collectionUDT{
+		"one": {UserID: "user-1"},
+	}), DefaultMapper, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]customUDTCodec
+	err = gocql.Unmarshal(mapType, data, udtWrapValue(reflect.ValueOf(&got), DefaultMapper, false))
+	if !errors.Is(err, errCustomUDTCodec) {
+		t.Fatalf("custom UDT unmarshaler was bypassed: %v", err)
+	}
+}
+
+func TestUDTPromotedCodecDoesNotOverrideAutomaticMapping(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "promoted_codec_udt", "",
+		gocql.UDTField{Name: "value", Type: textType},
+	)
+
+	tests := []struct {
+		name  string
+		value interface{}
+		new   func() interface{}
+	}{
+		{
+			name:  "scalar codec",
+			value: promotedScalarCodecUDT{Value: "expected"},
+			new:   func() interface{} { return new(promotedScalarCodecUDT) },
+		},
+		{
+			name: "scalar pointer codec",
+			value: promotedScalarPointerCodecUDT{
+				promotedScalarCodec: new(promotedScalarCodec),
+				Value:               "expected",
+			},
+			new: func() interface{} { return new(promotedScalarPointerCodecUDT) },
+		},
+		{
+			name:  "UDT codec",
+			value: promotedUDTCodecUDT{Value: "expected"},
+			new:   func() interface{} { return new(promotedUDTCodecUDT) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := gocql.Marshal(valueType, udtWrapValue(reflect.ValueOf(tt.value), DefaultMapper, false))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := tt.new()
+			if err := gocql.Unmarshal(valueType, data, udtWrapValue(reflect.ValueOf(got), DefaultMapper, false)); err != nil {
+				t.Fatal(err)
+			}
+			wantValue := reflect.ValueOf(tt.value).FieldByName("Value").String()
+			gotValue := reflect.ValueOf(got).Elem().FieldByName("Value").String()
+			if gotValue != wantValue {
+				t.Fatalf("got %q, expected %q", gotValue, wantValue)
+			}
+		})
+	}
+}
+
+func TestUDTExplicitCodecOverridesPromotedCodec(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "explicit_codec_udt", "",
+		gocql.UDTField{Name: "value", Type: textType},
+	)
+
+	tests := []struct {
+		name  string
+		info  gocql.TypeInfo
+		value interface{}
+		plain interface{}
+		new   func() interface{}
+	}{
+		{
+			name:  "list element",
+			info:  gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil, valueType),
+			value: []explicitScalarCodecUDT{{promotedScalarCodec: promotedScalarCodec{}, Value: "expected"}},
+			plain: []promotedScalarCodecUDT{{Value: "expected"}},
+			new:   func() interface{} { return new([]explicitScalarCodecUDT) },
+		},
+		{
+			name:  "map value",
+			info:  gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType),
+			value: map[string]explicitScalarCodecUDT{"one": {promotedScalarCodec: promotedScalarCodec{}, Value: "expected"}},
+			plain: map[string]promotedScalarCodecUDT{"one": {Value: "expected"}},
+			new:   func() interface{} { return new(map[string]explicitScalarCodecUDT) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := gocql.Marshal(tt.info, udtWrapValue(reflect.ValueOf(tt.value), DefaultMapper, false))
+			if !errors.Is(err, errExplicitScalarCodec) {
+				t.Fatalf("explicit marshaler was bypassed: %v", err)
+			}
+
+			data, err := gocql.Marshal(tt.info, udtWrapValue(reflect.ValueOf(tt.plain), DefaultMapper, false))
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = gocql.Unmarshal(tt.info, data, udtWrapValue(reflect.ValueOf(tt.new()), DefaultMapper, false))
+			if !errors.Is(err, errExplicitScalarCodec) {
+				t.Fatalf("explicit unmarshaler was bypassed: %v", err)
+			}
+		})
+	}
+}
+
+func TestUDTCollectionUnmarshalRejectsNonPointer(t *testing.T) {
+	textType := gocql.NewNativeType(4, gocql.TypeText)
+	valueType := gocql.NewUDTType(4, "collection_udt", "",
+		gocql.UDTField{Name: "user_id", Type: textType},
+	)
+	mapType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeMap), textType, valueType)
+	listType := gocql.NewCollectionType(gocql.NewNativeType(4, gocql.TypeList), nil, valueType)
+
+	tests := []struct {
+		name  string
+		info  gocql.TypeInfo
+		value interface{}
+		dest  interface{}
+	}{
+		{
+			name:  "map",
+			info:  mapType,
+			value: map[string]collectionUDT{"one": {UserID: "user-1"}},
+			dest:  map[string]collectionUDT{},
+		},
+		{
+			name:  "slice",
+			info:  listType,
+			value: []collectionUDT{{UserID: "user-1"}},
+			dest:  []collectionUDT{},
+		},
+		{
+			name:  "array",
+			info:  listType,
+			value: [1]collectionUDT{{UserID: "user-1"}},
+			dest:  [1]collectionUDT{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := gocql.Marshal(tt.info, udtWrapValue(reflect.ValueOf(tt.value), DefaultMapper, false))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = gocql.Unmarshal(tt.info, data, udtWrapValue(reflect.ValueOf(tt.dest), DefaultMapper, false))
+			if err == nil {
+				t.Fatal("expected non-pointer destination error")
+			}
+		})
+	}
+}
+
+func BenchmarkUDTWrapValueScalar(b *testing.B) {
+	value := reflect.ValueOf(new(int))
+	_ = udtWrapValue(value, DefaultMapper, false)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = udtWrapValue(value, DefaultMapper, false)
+	}
+}
+
+func BenchmarkContainsUDTScalarUncached(b *testing.B) {
+	typeOfValue := reflect.TypeOf(new(int))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = containsUDT(typeOfValue, make(map[reflect.Type]bool))
+	}
+}


### PR DESCRIPTION
Closes #188.

## Summary

- support automatic `gocqlx.UDT` values and keys in maps
- recursively support mapper-aware UDTs in nested maps, lists, sets, slices, and arrays
- preserve the configured mapper and strict mode throughout nested codecs
- apply the same wrapping to batch bind paths without mutating caller arguments
- preserve `gocql.Marshaler`, `gocql.Unmarshaler`, `gocql.UDTMarshaler`, and `gocql.UDTUnmarshaler` precedence
- use read-only field traversal while marshaling, preserving nil fields and avoiding mutation or reflection panics for map and collection elements
- clear stale automatic UDT destinations when a top-level or nested CQL UDT is null

## Scope and ownership

The following behavior belongs in gocqlx and is implemented here:

- recognition of the `gocqlx.UDT` marker
- mapper-aware `db` field lookup and strict-mode handling
- read-only marshaling traversal
- preservation of existing gocql custom-codec precedence
- query and batch wrapping

Two narrow compatibility plugs remain internal while upstream gocql APIs and behavior are discussed:

1. **Recursive collection framing**
   
   `udtCodec` owns mapper-aware traversal of collection elements and currently duplicates private gocql collection framing. This is internal implementation detail; no new public framing API is exposed by gocqlx.
   
   Upstream request: https://github.com/scylladb/gocql/issues/985
   
   Removal condition: replace the custom framing after gocql provides a recursive collection-element codec hook and gocqlx raises its minimum dependency to that release.

2. **Null automatic UDT clearing**
   
   gocql currently leaves stale destination state when a wholly null UDT is decoded through `UDTUnmarshaler`. gocqlx handles this only for its own automatic UDT wrapper and only when `data == nil`, at both top-level and nested positions. User-defined `UDTUnmarshaler` implementations remain delegated to gocql unchanged.
   
   Upstream bug: https://github.com/scylladb/gocql/issues/986
   
   Removal condition: remove the targeted workaround after gocql defines and implements null handling for `UDTUnmarshaler` and gocqlx adopts that release.

Mapper-aware recursion inside CQL tuples and vectors is intentionally deferred to #395. Slices and arrays in this PR are Go representations of the supported CQL list and set paths.

General gocql collection extension APIs and null semantics for arbitrary custom UDT codecs are intentionally out of scope for this PR.

## Coverage

- concrete and pointer map values
- UDT map keys
- interface-typed UDT values
- nested maps, lists, sets, slices, and arrays
- strict mode on marshal and unmarshal
- nested UDT map fields
- nil, empty, and null-valued maps
- top-level and nested null UDT values
- custom gocql codec precedence
- caller argument preservation during batch binding
- collection framing parity with gocql
- live Scylla round trips for UDT map values and keys

## Testing

- `go test -race -count=1 . ./qb ./table ./migrate ./dbutil ./gocqlxtest`
- `go test -run "^$" -tags all ./...`
- `go vet ./...`
- `git diff --check`

`golangci-lint` was unavailable in the local environment; repository CI remains the lint authority.
