### PR TITLE
migrate: expose structured migration errors

### DIFF
--- a/migrate/callback.go
+++ b/migrate/callback.go
@@ -6,7 +6,6 @@ package migrate
 
 import (
 	"context"
-	"errors"
 
 	"github.com/scylladb/gocqlx/v3"
 )
@@ -64,7 +63,7 @@ func (r CallbackRegister) Callback(ctx context.Context, session gocqlx.Session, 
 	f, ok := r[nameEvent{name, ev}]
 	if !ok {
 		if ev == CallComment {
-			return errors.New("missing handler")
+			return &MissingCallbackHandlerError{Name: name}
 		}
 		return nil
 	}

--- a/migrate/checksum.go
+++ b/migrate/checksum.go
@@ -21,7 +21,7 @@ func checksum(b []byte) string {
 func fileChecksum(f fs.FS, path string) (string, error) {
 	file, err := f.Open(path)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	defer func() {
 		_ = file.Close()

--- a/migrate/checksum_test.go
+++ b/migrate/checksum_test.go
@@ -5,8 +5,11 @@
 package migrate
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"testing"
+	"testing/fstest"
 )
 
 func TestFileChecksum(t *testing.T) {
@@ -16,5 +19,12 @@ func TestFileChecksum(t *testing.T) {
 	}
 	if c != "bbe02f946d5455d74616fc9777557c22" {
 		t.Fatal(c)
+	}
+}
+
+func TestFileChecksumOpenError(t *testing.T) {
+	_, err := fileChecksum(fstest.MapFS{}, "missing")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("fileChecksum() error = %v, expected fs.ErrNotExist", err)
 	}
 }

--- a/migrate/errors.go
+++ b/migrate/errors.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2026 ScyllaDB
+// Use of this source code is governed by a ALv2-style
+// license that can be found in the LICENSE file.
+
+package migrate
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrNoMigrations indicates that the migration file system contains no CQL files.
+	ErrNoMigrations = errors.New("no migration files found")
+	// ErrDatabaseAhead indicates that the database contains more applied migrations
+	// than the migration file system.
+	ErrDatabaseAhead = errors.New("database is ahead")
+	// ErrInconsistentMigrations indicates that an applied migration does not match
+	// the migration at the same position in the file system.
+	ErrInconsistentMigrations = errors.New("inconsistent migrations")
+	// ErrChecksumMismatch indicates that an applied migration file's checksum has changed.
+	ErrChecksumMismatch = errors.New("migration checksum mismatch")
+	// ErrNoMigrationStatements indicates that a migration file contains no statements.
+	ErrNoMigrationStatements = errors.New("no migration statements found")
+	// ErrMissingCallbackHandler indicates that a CALL comment has no registered handler.
+	ErrMissingCallbackHandler = errors.New("missing callback handler")
+)
+
+// NoMigrationsError describes the file pattern for which no migrations were found.
+type NoMigrationsError struct {
+	Pattern string
+}
+
+func (e *NoMigrationsError) Error() string {
+	return fmt.Sprintf("no migration files found matching %q", e.Pattern)
+}
+
+// Unwrap allows errors.Is to match ErrNoMigrations.
+func (e *NoMigrationsError) Unwrap() error {
+	return ErrNoMigrations
+}
+
+// DatabaseAheadError describes migration counts when the database contains
+// more applied migrations than the file system.
+type DatabaseAheadError struct {
+	Applied   int
+	Available int
+}
+
+func (e *DatabaseAheadError) Error() string {
+	return fmt.Sprintf("database is ahead: %d migrations applied, %d available", e.Applied, e.Available)
+}
+
+// Unwrap allows errors.Is to match ErrDatabaseAhead.
+func (e *DatabaseAheadError) Unwrap() error {
+	return ErrDatabaseAhead
+}
+
+// InconsistentMigrationError describes a mismatch between the applied and
+// file-system migration sequences.
+type InconsistentMigrationError struct {
+	Expected string
+	Actual   string
+	Index    int
+}
+
+func (e *InconsistentMigrationError) Error() string {
+	return fmt.Sprintf("inconsistent migrations found, expected %q got %q at %d", e.Expected, e.Actual, e.Index)
+}
+
+// Unwrap allows errors.Is to match ErrInconsistentMigrations.
+func (e *InconsistentMigrationError) Unwrap() error {
+	return ErrInconsistentMigrations
+}
+
+// ChecksumMismatchError describes a migration file whose checksum differs
+// from the checksum recorded in the database.
+type ChecksumMismatchError struct {
+	Path     string
+	Expected string
+	Actual   string
+}
+
+func (e *ChecksumMismatchError) Error() string {
+	return fmt.Sprintf("file %q was tampered with, expected md5 %s, got %s", e.Path, e.Expected, e.Actual)
+}
+
+// Unwrap allows errors.Is to match ErrChecksumMismatch.
+func (e *ChecksumMismatchError) Unwrap() error {
+	return ErrChecksumMismatch
+}
+
+// NoMigrationStatementsError describes a migration file containing no statements.
+type NoMigrationStatementsError struct {
+	Path string
+}
+
+func (e *NoMigrationStatementsError) Error() string {
+	return fmt.Sprintf("no migration statements found in %q", e.Path)
+}
+
+// Unwrap allows errors.Is to match ErrNoMigrationStatements.
+func (e *NoMigrationStatementsError) Unwrap() error {
+	return ErrNoMigrationStatements
+}
+
+// MissingCallbackHandlerError describes a CALL comment for which no callback
+// handler is registered.
+type MissingCallbackHandlerError struct {
+	cause     error
+	Name      string
+	Statement int
+}
+
+func (e *MissingCallbackHandlerError) Error() string {
+	if e.Statement > 0 {
+		if e.cause != nil {
+			return fmt.Sprintf("statement %d: %v", e.Statement, e.cause)
+		}
+		return fmt.Sprintf("statement %d: missing callback handler for %q", e.Statement, e.Name)
+	}
+	if e.cause != nil {
+		return e.cause.Error()
+	}
+	return fmt.Sprintf("missing callback handler for %q", e.Name)
+}
+
+// Unwrap preserves the callback error chain and allows errors.Is to match
+// ErrMissingCallbackHandler.
+func (e *MissingCallbackHandlerError) Unwrap() error {
+	if e.cause != nil {
+		return e.cause
+	}
+	return ErrMissingCallbackHandler
+}

--- a/migrate/errors_test.go
+++ b/migrate/errors_test.go
@@ -1,0 +1,139 @@
+// Copyright (C) 2026 ScyllaDB
+// Use of this source code is governed by a ALv2-style
+// license that can be found in the LICENSE file.
+
+package migrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/scylladb/gocqlx/v3"
+)
+
+func TestNoMigrationsError(t *testing.T) {
+	err := &NoMigrationsError{Pattern: "*.cql"}
+	if !errors.Is(err, ErrNoMigrations) {
+		t.Fatalf("errors.Is(%v, ErrNoMigrations) = false", err)
+	}
+	var target *NoMigrationsError
+	if !errors.As(err, &target) || target != err {
+		t.Fatalf("errors.As(%v) did not return the original error", err)
+	}
+	if got, want := err.Error(), `no migration files found matching "*.cql"`; got != want {
+		t.Fatalf("Error() = %q, expected %q", got, want)
+	}
+}
+
+func TestDatabaseAheadError(t *testing.T) {
+	err := &DatabaseAheadError{
+		Applied:   3,
+		Available: 2,
+	}
+	if !errors.Is(err, ErrDatabaseAhead) {
+		t.Fatalf("errors.Is(%v, ErrDatabaseAhead) = false", err)
+	}
+	var target *DatabaseAheadError
+	if !errors.As(err, &target) || target != err {
+		t.Fatalf("errors.As(%v) did not return the original error", err)
+	}
+	if got, want := err.Error(), "database is ahead: 3 migrations applied, 2 available"; got != want {
+		t.Fatalf("Error() = %q, expected %q", got, want)
+	}
+}
+
+func TestInconsistentMigrationError(t *testing.T) {
+	err := &InconsistentMigrationError{
+		Expected: "001.cql",
+		Actual:   "002.cql",
+		Index:    1,
+	}
+	if !errors.Is(err, ErrInconsistentMigrations) {
+		t.Fatalf("errors.Is(%v, ErrInconsistentMigrations) = false", err)
+	}
+	var target *InconsistentMigrationError
+	if !errors.As(err, &target) || target != err {
+		t.Fatalf("errors.As(%v) did not return the original error", err)
+	}
+	if got, want := err.Error(), `inconsistent migrations found, expected "001.cql" got "002.cql" at 1`; got != want {
+		t.Fatalf("Error() = %q, expected %q", got, want)
+	}
+}
+
+func TestChecksumMismatchError(t *testing.T) {
+	err := &ChecksumMismatchError{
+		Path:     "001.cql",
+		Expected: "expected",
+		Actual:   "actual",
+	}
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("errors.Is(%v, ErrChecksumMismatch) = false", err)
+	}
+	var target *ChecksumMismatchError
+	if !errors.As(err, &target) || target != err {
+		t.Fatalf("errors.As(%v) did not return the original error", err)
+	}
+	if got, want := err.Error(), `file "001.cql" was tampered with, expected md5 expected, got actual`; got != want {
+		t.Fatalf("Error() = %q, expected %q", got, want)
+	}
+}
+
+func TestNoMigrationStatementsError(t *testing.T) {
+	err := &NoMigrationStatementsError{Path: "001.cql"}
+	if !errors.Is(err, ErrNoMigrationStatements) {
+		t.Fatalf("errors.Is(%v, ErrNoMigrationStatements) = false", err)
+	}
+	var target *NoMigrationStatementsError
+	if !errors.As(err, &target) || target != err {
+		t.Fatalf("errors.As(%v) did not return the original error", err)
+	}
+	if got, want := err.Error(), `no migration statements found in "001.cql"`; got != want {
+		t.Fatalf("Error() = %q, expected %q", got, want)
+	}
+}
+
+func TestMissingCallbackHandlerError(t *testing.T) {
+	err := CallbackRegister{}.Callback(context.Background(), gocqlx.Session{}, CallComment, "seed")
+	if !errors.Is(err, ErrMissingCallbackHandler) {
+		t.Fatalf("errors.Is(%v, ErrMissingCallbackHandler) = false", err)
+	}
+	var target *MissingCallbackHandlerError
+	if !errors.As(err, &target) {
+		t.Fatalf("errors.As(%v) did not return MissingCallbackHandlerError", err)
+	}
+	if target.Name != "seed" {
+		t.Fatalf("MissingCallbackHandlerError.Name = %q, expected %q", target.Name, "seed")
+	}
+	if target.Statement != 0 {
+		t.Fatalf("MissingCallbackHandlerError.Statement = %d, expected 0", target.Statement)
+	}
+	if got, want := err.Error(), `missing callback handler for "seed"`; got != want {
+		t.Fatalf("Error() = %q, expected %q", got, want)
+	}
+}
+
+func TestMissingCallbackHandlerErrorPreservesCause(t *testing.T) {
+	missing := &MissingCallbackHandlerError{Name: "child"}
+	cause := fmt.Errorf("dispatch nested callback: %w", missing)
+	err := &MissingCallbackHandlerError{
+		Name:      missing.Name,
+		Statement: 2,
+		cause:     cause,
+	}
+
+	if !errors.Is(err, cause) {
+		t.Fatalf("errors.Is(%v, cause) = false", err)
+	}
+	if !errors.Is(err, ErrMissingCallbackHandler) {
+		t.Fatalf("errors.Is(%v, ErrMissingCallbackHandler) = false", err)
+	}
+	var target *MissingCallbackHandlerError
+	if !errors.As(err, &target) || target != err {
+		t.Fatalf("errors.As(%v) did not return the contextual error", err)
+	}
+	if got, want := err.Error(), `statement 2: dispatch nested callback: missing callback handler for "child"`; got != want {
+		t.Fatalf("Error() = %q, expected %q", got, want)
+	}
+}

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -7,6 +7,7 @@ package migrate
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -163,25 +164,36 @@ func FromFS(ctx context.Context, session gocqlx.Session, f fs.FS) error {
 		return fmt.Errorf("list migrations: %w", err)
 	}
 	if len(fm) == 0 {
-		return fmt.Errorf("no migration files found")
+		return &NoMigrationsError{Pattern: "*.cql"}
 	}
 	sort.Strings(fm)
 
 	// verify migrations
 	if len(dbm) > len(fm) {
-		return fmt.Errorf("database is ahead")
+		return &DatabaseAheadError{
+			Applied:   len(dbm),
+			Available: len(fm),
+		}
 	}
 
 	for i := 0; i < len(dbm); i++ {
 		if dbm[i].Name != fm[i] {
-			return fmt.Errorf("inconsistent migrations found, expected %q got %q at %d", dbm[i].Name, fm[i], i)
+			return &InconsistentMigrationError{
+				Expected: dbm[i].Name,
+				Actual:   fm[i],
+				Index:    i,
+			}
 		}
 		c, err := fileChecksum(f, fm[i])
 		if err != nil {
-			return fmt.Errorf("calculate checksum for %q: %s", fm[i], err)
+			return fmt.Errorf("calculate checksum for %q: %w", fm[i], err)
 		}
 		if dbm[i].Checksum != c {
-			return fmt.Errorf("file %q was tampered with, expected md5 %s", fm[i], dbm[i].Checksum)
+			return &ChecksumMismatchError{
+				Path:     fm[i],
+				Expected: dbm[i].Checksum,
+				Actual:   c,
+			}
 		}
 	}
 
@@ -312,9 +324,17 @@ func applyMigration(ctx context.Context, session gocqlx.Session, f fs.FS, path s
 		if cb := isCallback(stmt); cb != "" {
 			// Handle callback commands (e.g., "-- CALL function_name;")
 			if Callback == nil {
-				return fmt.Errorf("statement %d: missing callback handler while trying to call %s", i, cb)
+				return &MissingCallbackHandlerError{Name: cb, Statement: i}
 			}
 			if err := Callback(operationCtx, session, CallComment, cb); err != nil {
+				var missing *MissingCallbackHandlerError
+				if errors.As(err, &missing) {
+					return &MissingCallbackHandlerError{
+						Name:      missing.Name,
+						Statement: i,
+						cause:     err,
+					}
+				}
 				return fmt.Errorf("callback %s: %w", cb, err)
 			}
 		} else if stmt != "" && !isComment(stmt) {
@@ -334,7 +354,7 @@ func applyMigration(ctx context.Context, session gocqlx.Session, f fs.FS, path s
 		}
 	}
 	if i == 0 {
-		return fmt.Errorf("no migration statements found in %q", info.Name)
+		return &NoMigrationStatementsError{Path: info.Name}
 	}
 
 	if Callback != nil && i > done {

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -61,6 +61,10 @@ func TestPending(t *testing.T) {
 
 		f := memfs.New()
 		writeFile(t, f, 0, fmt.Sprintf(insertMigrate, 0)+";")
+		openErr := errors.New("open migration")
+		if _, err := migrate.Pending(ctx, session, openErrorFS{FS: f, Path: "0.cql", Err: openErr}); !errors.Is(err, openErr) {
+			t.Fatalf("Pending() error = %v, expected %v", err, openErr)
+		}
 
 		pending, err := migrate.Pending(ctx, session, f)
 		if err != nil {
@@ -104,6 +108,32 @@ func TestMigration(t *testing.T) {
 
 	ctx := context.Background()
 
+	t.Run("no migrations", func(t *testing.T) {
+		err := migrate.FromFS(ctx, session, memfs.New())
+		var noMigrations *migrate.NoMigrationsError
+		if !errors.Is(err, migrate.ErrNoMigrations) || !errors.As(err, &noMigrations) {
+			t.Fatalf("FromFS() error = %v, expected NoMigrationsError", err)
+		}
+		if noMigrations.Pattern != "*.cql" {
+			t.Fatalf("NoMigrationsError.Pattern = %q, expected %q", noMigrations.Pattern, "*.cql")
+		}
+	})
+
+	t.Run("no migration statements", func(t *testing.T) {
+		f := memfs.New()
+		if err := f.WriteFile("0.cql", nil, fs.ModePerm); err != nil {
+			t.Fatal(err)
+		}
+		err := migrate.FromFS(ctx, session, f)
+		var noStatements *migrate.NoMigrationStatementsError
+		if !errors.Is(err, migrate.ErrNoMigrationStatements) || !errors.As(err, &noStatements) {
+			t.Fatalf("FromFS() error = %v, expected NoMigrationStatementsError", err)
+		}
+		if noStatements.Path != "0.cql" {
+			t.Fatalf("NoMigrationStatementsError.Path = %q, expected %q", noStatements.Path, "0.cql")
+		}
+	})
+
 	t.Run("init", func(t *testing.T) {
 		if err := migrate.FromFS(ctx, session, makeTestFS(t, 2)); err != nil {
 			t.Fatal(err)
@@ -124,21 +154,60 @@ func TestMigration(t *testing.T) {
 
 	t.Run("ahead", func(t *testing.T) {
 		err := migrate.FromFS(ctx, session, makeTestFS(t, 2))
-		if err == nil || !strings.Contains(err.Error(), "ahead") {
-			t.Fatal("expected error")
-		} else {
-			t.Log(err)
+		var ahead *migrate.DatabaseAheadError
+		if !errors.Is(err, migrate.ErrDatabaseAhead) || !errors.As(err, &ahead) {
+			t.Fatalf("FromFS() error = %v, expected DatabaseAheadError", err)
+		}
+		if ahead.Applied != 4 || ahead.Available != 2 {
+			t.Fatalf("DatabaseAheadError = %#v", ahead)
 		}
 	})
 
-	t.Run("tempered with file", func(t *testing.T) {
+	t.Run("inconsistent migrations", func(t *testing.T) {
+		f := memfs.New()
+		if err := f.WriteFile("00.cql", []byte(fmt.Sprintf(insertMigrate, 0)+";"), fs.ModePerm); err != nil {
+			t.Fatal(err)
+		}
+		for i := 1; i < 4; i++ {
+			writeFile(t, f, i, fmt.Sprintf(insertMigrate, i)+";")
+		}
+
+		err := migrate.FromFS(ctx, session, f)
+		var mismatch *migrate.InconsistentMigrationError
+		if !errors.Is(err, migrate.ErrInconsistentMigrations) || !errors.As(err, &mismatch) {
+			t.Fatalf("FromFS() error = %v, expected InconsistentMigrationError", err)
+		}
+		if mismatch.Expected != "0.cql" || mismatch.Actual != "00.cql" || mismatch.Index != 0 {
+			t.Fatalf("InconsistentMigrationError = %#v", mismatch)
+		}
+	})
+
+	t.Run("checksum open error", func(t *testing.T) {
+		openErr := errors.New("open migration")
+		err := migrate.FromFS(ctx, session, openErrorFS{
+			FS:   makeTestFS(t, 4),
+			Path: "0.cql",
+			Err:  openErr,
+		})
+		if !errors.Is(err, openErr) {
+			t.Fatalf("FromFS() error = %v, expected %v", err, openErr)
+		}
+		if !strings.Contains(err.Error(), `calculate checksum for "0.cql"`) {
+			t.Fatalf("FromFS() error = %v, expected checksum context", err)
+		}
+	})
+
+	t.Run("tampered with file", func(t *testing.T) {
 		f := makeTestFS(t, 4)
 		writeFile(t, f, 3, "SELECT * FROM bla;")
 
-		if err := migrate.FromFS(ctx, session, f); err == nil || !strings.Contains(err.Error(), "tampered") {
-			t.Fatal("expected error")
-		} else {
-			t.Log(err)
+		err := migrate.FromFS(ctx, session, f)
+		var mismatch *migrate.ChecksumMismatchError
+		if !errors.Is(err, migrate.ErrChecksumMismatch) || !errors.As(err, &mismatch) {
+			t.Fatalf("FromFS() error = %v, expected ChecksumMismatchError", err)
+		}
+		if mismatch.Path != "3.cql" || mismatch.Expected == "" || mismatch.Actual == "" {
+			t.Fatalf("ChecksumMismatchError = %#v", mismatch)
 		}
 	})
 }
@@ -381,6 +450,80 @@ func TestMigrationCallback(t *testing.T) {
 		}
 		assertCallbacks(t, 2, 2, 2)
 	})
+}
+
+func TestMigrationMissingCallbackHandler(t *testing.T) {
+	previousCallback := migrate.Callback
+	defer func() {
+		migrate.Callback = previousCallback
+	}()
+
+	session := gocqlxtest.CreateSession(t)
+	defer session.Close()
+	recreateTables(t, session)
+
+	f := memfs.New()
+	if err := f.WriteFile("0.cql", []byte("-- CALL seed;"), fs.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	nestedErr := fmt.Errorf(
+		"dispatch nested callback: %w",
+		&migrate.MissingCallbackHandlerError{Name: "child"},
+	)
+
+	for _, test := range []struct {
+		name     string
+		callback migrate.CallbackFunc
+		wantName string
+		wantErr  string
+		cause    error
+	}{
+		{
+			name:     "nil callback",
+			wantName: "seed",
+			wantErr:  `apply migration "0.cql": statement 1: missing callback handler for "seed"`,
+		},
+		{
+			name:     "callback register",
+			callback: migrate.CallbackRegister{}.Callback,
+			wantName: "seed",
+			wantErr:  `apply migration "0.cql": statement 1: missing callback handler for "seed"`,
+		},
+		{
+			name: "nested callback",
+			callback: func(_ context.Context, _ gocqlx.Session, ev migrate.CallbackEvent, _ string) error {
+				if ev == migrate.CallComment {
+					return nestedErr
+				}
+				return nil
+			},
+			wantName: "child",
+			wantErr:  `apply migration "0.cql": statement 1: dispatch nested callback: missing callback handler for "child"`,
+			cause:    nestedErr,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			migrate.Callback = test.callback
+
+			err := migrate.FromFS(context.Background(), session, f)
+			if !errors.Is(err, migrate.ErrMissingCallbackHandler) {
+				t.Fatalf("FromFS() error = %v, expected ErrMissingCallbackHandler", err)
+			}
+			var missing *migrate.MissingCallbackHandlerError
+			if !errors.As(err, &missing) {
+				t.Fatalf("FromFS() error = %v, expected MissingCallbackHandlerError", err)
+			}
+			if missing.Name != test.wantName || missing.Statement != 1 {
+				t.Fatalf("MissingCallbackHandlerError = %#v", missing)
+			}
+			if test.cause != nil && !errors.Is(err, test.cause) {
+				t.Fatalf("FromFS() error = %v, expected cause %v", err, test.cause)
+			}
+			if got := err.Error(); got != test.wantErr {
+				t.Fatalf("FromFS() error = %q, expected %q", got, test.wantErr)
+			}
+		})
+	}
 }
 
 func TestMigrationRecordsProgressAfterContextCanceled(t *testing.T) {
@@ -685,6 +828,19 @@ type queryObserverFunc func(context.Context, gocql.ObservedQuery)
 
 func (f queryObserverFunc) ObserveQuery(ctx context.Context, query gocql.ObservedQuery) {
 	f(ctx, query)
+}
+
+type openErrorFS struct {
+	fs.FS
+	Path string
+	Err  error
+}
+
+func (f openErrorFS) Open(name string) (fs.File, error) {
+	if name == f.Path {
+		return nil, f.Err
+	}
+	return f.FS.Open(name)
 }
 
 func countMigrations(tb testing.TB, session gocqlx.Session) int {


### PR DESCRIPTION
Follow-up to #383.

- expose sentinels for simple migration states
- expose typed errors for migration-name and checksum mismatches
- preserve filesystem errors through `fileChecksum`, `Pending`, and `FromFS`
- update callers and tests to use `errors.Is`/`errors.As`

Validation:
- `go test ./...`
- `go test -cpu 1 -count=1 -cover -race -tags all ./migrate` (78.1% coverage)
- `make check`